### PR TITLE
Add responsive footer - issue #26

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,8 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/prefer-stateless-function": 0,
     "import/extensions": 0,
-    "import/no-extraneous-dependencies": 0
+    "import/no-extraneous-dependencies": 0,
+    "linebreak-style": 0
    },
    "settings": {
      "import/resolver": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,8 +12,7 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/prefer-stateless-function": 0,
     "import/extensions": 0,
-    "import/no-extraneous-dependencies": 0,
-    "linebreak-style": 0
+    "import/no-extraneous-dependencies": 0
    },
    "settings": {
      "import/resolver": {

--- a/src/scenes/home/footer/footer.css
+++ b/src/scenes/home/footer/footer.css
@@ -9,7 +9,7 @@
 
 .left {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   flex: 0 0 40%;
   justify-content: center;
   text-align: center;
@@ -23,16 +23,14 @@
   text-align: center;
   text-decoration: none;
 }
-.smContainer {
+.smContactFooterContainer {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 0 40px;
+  flex: 0 0 80%;
 }
-.sm {
-  padding: 0 10px;
-}
+
 .center {
   display: flex;
   flex: 0 0 20%;
@@ -57,4 +55,28 @@
   text-decoration: none;
   padding: 10px 40px;
   color: #F7F7F7;
+}
+
+@media screen and (max-width: 979px) {
+  .center {
+    display:none;
+  }
+  .left {
+    flex: 0 0 50%;
+  }
+  .right {
+    flex: 0 0 50%;
+  }
+}
+
+@media screen and (max-width: 595px) {
+  .center {
+    display:none;
+  }
+  .left {
+    flex: 0 0 100%;
+  }
+  .right {
+    display:none
+  }
 }

--- a/src/scenes/home/footer/footer.css
+++ b/src/scenes/home/footer/footer.css
@@ -1,82 +1,95 @@
-
 .footer {
   background-color: #4A4A4A;
   height: 150px;
+  padding: 0 32px;
+}
+
+.content {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  height: 100%;
 }
 
-.left {
-  display: flex;
-  flex-direction: row;
-  flex: 0 0 40%;
-  justify-content: center;
-  text-align: center;
-}
-.contact {
-  flex-direction: row;
-  justify-content: center;
-}
-.left a {
-  color: #F7F7F7;
-  text-align: center;
-  text-decoration: none;
-}
-.smContactFooterContainer {
+.block {
+  flex: 1 0 40%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  padding: 32px 0;
+  justify-content: space-around;
   align-items: center;
-  flex: 0 0 80%;
+  overflow: hidden;
 }
 
-.center {
-  display: flex;
-  flex: 0 0 20%;
-  justify-content: center;
-}
-
-.right {
-  display: flex;
-  flex: 0 0 40%;
-  align-items: center;
-
-}
-
-.nav {
-  display: flex;
-  flex-flow: row wrap;
-  align-items: center;
+.email {
+  flex-direction: row;
   justify-content: center;
 }
 
-.nav a {
-  text-decoration: none;
-  padding: 10px 40px;
+.email a {
   color: #F7F7F7;
+  text-align: center;
+  text-decoration: none;
+}
+
+.logo {
+  display: flex;
+  flex: 1 0 20%;
+  justify-content: center;
+}
+
+.logo img {
+  height: 150px; 
+}
+
+.blockGroup {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  width: 55%;
+}
+
+.blockGroup a {
+  text-decoration: none;
+  color: #F7F7F7;
+  padding: 0 20px;
 }
 
 @media screen and (max-width: 979px) {
-  .center {
+
+  .logo {
     display:none;
   }
-  .left {
-    flex: 0 0 50%;
+
+}
+
+@media screen and (max-width: 768px) {
+  .pageLinks {
+    flex-direction: row;
   }
-  .right {
-    flex: 0 0 50%;
+
+  .blockGroup {
+    flex-direction: column;
+    height: 100%;
   }
 }
 
 @media screen and (max-width: 595px) {
-  .center {
+  .content {
+    flex-direction: column;
+  }
+
+  .logo {
     display:none;
   }
-  .left {
+  .contactLinks {
     flex: 0 0 100%;
   }
-  .right {
+  .pageLinks {
     display:none
+  }
+
+  .blockRow a {
+    padding: 10px 10px;
   }
 }

--- a/src/scenes/home/footer/footer.css
+++ b/src/scenes/home/footer/footer.css
@@ -111,7 +111,7 @@
     .block {
       justify-content: center;
       flex: 1 0 auto;
-      padding: 32px 0;
+      padding: 16px 0;
     }
 
     .email {

--- a/src/scenes/home/footer/footer.css
+++ b/src/scenes/home/footer/footer.css
@@ -1,7 +1,8 @@
 .footer {
   background-color: #4A4A4A;
-  height: 150px;
+  height: 225px;
   padding: 0 32px;
+  position: relative;
 }
 
 .content {
@@ -15,7 +16,7 @@
   flex: 1 0 40%;
   display: flex;
   flex-direction: column;
-  padding: 32px 0;
+  padding: 64px 0;
   justify-content: space-around;
   align-items: center;
   overflow: hidden;
@@ -36,17 +37,17 @@
   display: flex;
   flex: 1 0 20%;
   justify-content: center;
+  align-items: center;
 }
 
 .logo img {
-  height: 150px; 
+  height: 150px;
 }
 
 .blockGroup {
   display: flex;
   align-items: center;
   justify-content: space-around;
-  width: 55%;
 }
 
 .blockGroup a {
@@ -55,41 +56,90 @@
   padding: 0 20px;
 }
 
-@media screen and (max-width: 979px) {
+.copyright {
+  position: absolute;
+  margin: 0 auto;
+  right: 0;
+  left: 0;
+  bottom: 10px;
+  width: 100;
+  color:#F7F7F7;
+  text-align: center;
+  font-size: 0.7rem;
+}
 
-  .logo {
-    display:none;
+@media screen and (min-width: 481px) and (max-width: 979px) {
+
+  .logo img {
+    height: 90px;
   }
 
 }
 
-@media screen and (max-width: 768px) {
-  .pageLinks {
-    flex-direction: row;
+@media screen and (min-width: 481px) and (max-width: 768px) {
+  .block {
+    padding: 32px 0;
   }
 
   .blockGroup {
     flex-direction: column;
-    height: 100%;
+    height: 100%; 
   }
 }
 
-@media screen and (max-width: 595px) {
-  .content {
-    flex-direction: column;
-  }
-
-  .logo {
-    display:none;
-  }
-  .contactLinks {
-    flex: 0 0 100%;
-  }
-  .pageLinks {
-    display:none
+@media screen and (max-width: 616px) {
+  .email {
+    font-size: 0.8rem;
   }
 
   .blockRow a {
     padding: 10px 10px;
   }
+}
+
+@media screen and (max-width: 480px) {
+
+    .footer {
+      height: 410px;
+      padding: 0px 16px;
+    }
+
+    .content {
+      display: block;
+    }
+
+    .block {
+      justify-content: center;
+      flex: 1 0 auto;
+      padding: 32px 0;
+    }
+
+    .email {
+      font-size: 1.3rem;
+      margin-bottom: 10px;
+    }
+
+    .logo {
+      flex: 0 1 auto;
+    }
+
+    .logo img {
+      height: 90px; 
+    }
+
+    .blockGroup {
+      font-size: 1.3rem;
+    }
+
+    .blockGroup a {
+      padding: 0 10px;
+    }
+
+    .blockGroup ~ .blockGroup {
+          margin-top: 16px;
+    }
+
+    .copyright {
+      font-size: 1rem;
+    }
 }

--- a/src/scenes/home/footer/footer.js
+++ b/src/scenes/home/footer/footer.js
@@ -1,10 +1,7 @@
 import React, { Component } from 'react';
 import centerLogo from 'images/Medal.svg';
-import fbImage from 'images/Facebook.svg';
-import ghImage from 'images/GitHub.svg';
-import twtImage from 'images/Icon-Twitter.svg';
-import liImage from 'images/LinkedIn.svg';
 import { Link } from 'react-router-dom';
+import SocialMedia from 'shared/components/socialMedia/socialMedia';
 import styles from './footer.css';
 
 class Footer extends Component {
@@ -12,22 +9,11 @@ class Footer extends Component {
     return (
       <div className={styles.footer}>
         <div className={styles.left}>
-          <div className={styles.contact} >
-            <a href="mailto:contact@operationcode.org">contact@operationcode.org</a>
-          </div>
-          <div className={styles.smContainer}>
-            <div className={styles.sm}>
-              <img src={twtImage} alt="" />
+          <div className={styles.smContactFooterContainer}>
+            <div className={styles.contact} >
+              <a href="mailto:contact@operationcode.org">contact@operationcode.org</a>
             </div>
-            <div className={styles.sm}>
-              <img src={ghImage} alt="" />
-            </div>
-            <div className={styles.sm}>
-              <img src={fbImage} alt="" />
-            </div>
-            <div className={styles.sm}>
-              <img src={liImage} alt="" />
-            </div>
+            <SocialMedia />
           </div>
         </div>
         <div className={styles.center}>

--- a/src/scenes/home/footer/footer.js
+++ b/src/scenes/home/footer/footer.js
@@ -8,25 +8,27 @@ class Footer extends Component {
   render() {
     return (
       <div className={styles.footer}>
-        <div className={styles.left}>
-          <div className={styles.smContactFooterContainer}>
-            <div className={styles.contact} >
+        <div className={styles.content}>
+          <div className={`${styles.block} ${styles.contactLinks}`}>
+            <div className={styles.email} >
               <a href="mailto:contact@operationcode.org">contact@operationcode.org</a>
             </div>
             <SocialMedia />
           </div>
-        </div>
-        <div className={styles.center}>
-          <img src={centerLogo} alt="" />
-        </div>
-        <div className={styles.right}>
-          <div className={styles.nav} >
-            <Link to="about">About&nbsp;Us</Link>
-            <Link to="programs">Our&nbsp;Programs</Link>
-            <Link to="involved">Our&nbsp;Partners</Link>
-            <Link to="involved">Get&nbsp;Involved</Link>
-            <Link to="blog">Blog</Link>
-            <Link to="contact">Contact</Link>
+          <div className={styles.logo}>
+            <img src={centerLogo} alt="" />
+          </div>
+          <div className={`${styles.block} ${styles.pageLinks}`}>
+            <div className={styles.blockGroup} >
+              <Link to="about">About&nbsp;Us</Link>
+              <Link to="programs">Our&nbsp;Programs</Link>
+              <Link to="involved">Our&nbsp;Partners</Link>
+            </div>
+            <div className={styles.blockGroup} >
+              <Link to="involved">Get&nbsp;Involved</Link>
+              <Link to="blog">Blog</Link>
+              <Link to="contact">Contact</Link>
+            </div>
           </div>
         </div>
       </div>

--- a/src/scenes/home/footer/footer.js
+++ b/src/scenes/home/footer/footer.js
@@ -9,7 +9,7 @@ class Footer extends Component {
     return (
       <div className={styles.footer}>
         <div className={styles.content}>
-          <div className={`${styles.block} ${styles.contactLinks}`}>
+          <div className={styles.block}>
             <div className={styles.email} >
               <a href="mailto:contact@operationcode.org">contact@operationcode.org</a>
             </div>
@@ -18,7 +18,7 @@ class Footer extends Component {
           <div className={styles.logo}>
             <img src={centerLogo} alt="" />
           </div>
-          <div className={`${styles.block} ${styles.pageLinks}`}>
+          <div className={styles.block}>
             <div className={styles.blockGroup} >
               <Link to="about">About&nbsp;Us</Link>
               <Link to="programs">Our&nbsp;Programs</Link>
@@ -30,6 +30,9 @@ class Footer extends Component {
               <Link to="contact">Contact</Link>
             </div>
           </div>
+        </div>
+        <div className={styles.copyright}>
+          Copyright 2017 Operation Code
         </div>
       </div>
     );

--- a/src/scenes/home/home.css
+++ b/src/scenes/home/home.css
@@ -5,6 +5,8 @@
     background: url("images/Family-2.png");
     background-size: 100%;
     background-repeat: no-repeat;
+
+    overflow: hidden;
 }
 
 .main {

--- a/src/shared/components/socialMedia/socialMedia.js
+++ b/src/shared/components/socialMedia/socialMedia.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+import fbImage from 'images/Facebook.svg';
+import ghImage from 'images/GitHub.svg';
+import twtImage from 'images/Icon-Twitter.svg';
+import liImage from 'images/LinkedIn.svg';
+import SocialMediaContainer from './socialMediaContainer/socialMediaContainer';
+import SocialMediaItem from './socialMediaItem/socialMediaItem';
+
+class SocialMedia extends Component {
+  render() {
+    return (
+      <SocialMediaContainer>
+        <SocialMediaItem smImage={fbImage} smText="Facebook" />
+        <SocialMediaItem smImage={ghImage} smText="Github" />
+        <SocialMediaItem smImage={twtImage} smText="Twitter" />
+        <SocialMediaItem smImage={liImage} smText="LinkedIn" />
+      </SocialMediaContainer>
+    );
+  }
+}
+
+export default SocialMedia;

--- a/src/shared/components/socialMedia/socialMediaContainer/socialMediaContainer.css
+++ b/src/shared/components/socialMedia/socialMediaContainer/socialMediaContainer.css
@@ -1,0 +1,7 @@
+.socialMediaContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+  width: 100%;
+}

--- a/src/shared/components/socialMedia/socialMediaContainer/socialMediaContainer.css
+++ b/src/shared/components/socialMedia/socialMediaContainer/socialMediaContainer.css
@@ -1,7 +1,5 @@
 .socialMediaContainer {
   display: flex;
-  flex-direction: row;
   justify-content: space-around;
   align-items: center;
-  width: 100%;
 }

--- a/src/shared/components/socialMedia/socialMediaContainer/socialMediaContainer.css
+++ b/src/shared/components/socialMedia/socialMediaContainer/socialMediaContainer.css
@@ -3,3 +3,9 @@
   justify-content: space-around;
   align-items: center;
 }
+
+@media screen and (min-width: 320px) and (max-width: 768px) {
+  .socialMediaContainer {
+    flex-wrap: wrap;
+  }
+}

--- a/src/shared/components/socialMedia/socialMediaContainer/socialMediaContainer.js
+++ b/src/shared/components/socialMedia/socialMediaContainer/socialMediaContainer.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styles from './socialMediaContainer.css';
+
+class SocialMediaContainer extends Component {
+  render() {
+    return (
+      <div className={styles.socialMediaContainer}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+SocialMediaContainer.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element).isRequired
+};
+
+export default SocialMediaContainer;

--- a/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.css
+++ b/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.css
@@ -1,0 +1,3 @@
+.socialMediaItem {
+
+}

--- a/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.css
+++ b/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.css
@@ -1,3 +1,3 @@
 .socialMediaItem {
-
+    padding: 0 10px;
 }

--- a/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.css
+++ b/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.css
@@ -4,7 +4,7 @@
 
 @media screen and (min-width: 320px) and (max-width: 768px) {
     .socialMediaItem {
-        padding: 0;
+        padding: 10px 0 0 0;
         flex-basis: 50%;
         text-align: center;
     }

--- a/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.css
+++ b/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.css
@@ -1,3 +1,11 @@
 .socialMediaItem {
     padding: 0 10px;
 }
+
+@media screen and (min-width: 320px) and (max-width: 768px) {
+    .socialMediaItem {
+        padding: 0;
+        flex-basis: 50%;
+        text-align: center;
+    }
+}

--- a/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.js
+++ b/src/shared/components/socialMedia/socialMediaItem/socialMediaItem.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './socialMediaItem.css';
+
+const SocialMediaItem = (props) => {
+  const {
+    smImage,
+    smText
+  } = props;
+  return (
+    <div className={styles.socialMediaItem}>
+      <img src={smImage} alt={smText} />
+    </div>
+  );
+};
+
+SocialMediaItem.propTypes = {
+  smImage: PropTypes.string.isRequired,
+  smText: PropTypes.string.isRequired
+};
+
+export default SocialMediaItem;


### PR DESCRIPTION
Issue #26: 

Adjust HTML layout within footer component and added responsive styles at various media queries to match @RobKriner's home page designs at: https://drive.google.com/drive/folders/0B9qH0-lcjAW5TFV6cDZaU1cwNEk (Desktop & Mobile Homepage).

Here are some screenshots at different screen widths (click to view full-screen): 

Desktop / Full Width: 
![screenclip](https://cloud.githubusercontent.com/assets/8835055/25648556/2aac39c8-2f9b-11e7-9c8f-2ceeab2b85f9.png)

Tablet / DevTools emulated iPad (Portrait):
![screenclip](https://cloud.githubusercontent.com/assets/8835055/25648934/f56ad6d0-2f9e-11e7-9064-ade767b609e2.png)

Phone / DevTools emulated iPhone 5 (portrait):
![screenclip](https://cloud.githubusercontent.com/assets/8835055/25648937/fd6fecd0-2f9e-11e7-9b7e-9ec0396081db.png)

Besides the markup and CSS for the Footer component, the only other changes I made were: 
* Turned off ESLint [rule](http://eslint.org/docs/rules/linebreak-style) enforcing linebreak-style - since I'm using a Windows computer, leaving this rule on preventing me from being able to compile w/ the Yarn dev server.

* Added CSS `overflow: hidden;` to the Home component's styles.  Without this, on smaller screen widths (tablet/phone), I was still able to scroll horizontally to the right (into a blank white area) when I shouldn't be able to.

* Forked @alexspence's branch `responsive-footer`, which introduced the Social Media component.  I added some media query CSS styles to this component so it would wrap/display correctly inside the footer at smaller screen sizes.  Some of the responsive styles I added seem coupled to the container (currently the Footer component) - maybe there is a long term solution to make this a truly 'reusable' component that doesn't have CSS styles that depend on the context of where it's used.  I'm still getting used to using CSS modules in this fashion (without a Less/Sass preprocessor), open to ideas for improvement.

