### PR TITLE
Add eslint command - yarn lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "start": "node scripts/start.js",
     "start:server": "node server",
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js --env=jsdom"
+    "test": "node scripts/test.js --env=jsdom",
+    "lint": "eslint src"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
Adds an eslint command.  Now just run `yarn lint` from command line to run the linter.