### PR TITLE
Add links to DonorBox - issue #31

### DIFF
--- a/src/scenes/home/header/topNav/topNav.js
+++ b/src/scenes/home/header/topNav/topNav.js
@@ -11,7 +11,7 @@ class TopNav extends Component {
         <NavItem to="programs" text="Our Programs" />
         <NavItem to="involved" text="Get Involved" />
         <NavItem to="blog" text="Blog" />
-        <NavItem to="donate" text="Donate" />
+        <NavItem to="https://donorbox.org/operationcode" text="Donate" isExternal />
         <NavItem to="join" text="Join" />
       </Nav>
     );

--- a/src/shared/components/donate/donate.js
+++ b/src/shared/components/donate/donate.js
@@ -19,7 +19,7 @@ const Donate = (props) => {
           our reach and help more veterans attend developer conferences.
         </p>
         <p>Thank you for helping us to get veterans coding!</p>
-        <LinkButton text="Donate Now" link="#" />
+        <LinkButton text="Donate Now" link="https://donorbox.org/operationcode" />
       </div>
     </Section>
   );

--- a/src/shared/components/nav/navItem/navItem.js
+++ b/src/shared/components/nav/navItem/navItem.js
@@ -4,9 +4,25 @@ import PropTypes from 'prop-types';
 import styles from './navItem.css';
 
 class NavItem extends PureComponent {
+
+  constructor() {
+    super();
+
+    // remove this if .eslintrc updated to parser:"babel-eslint", allowing class methods as => fns
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    if (!this.props.isExternal) {
+      return;
+    }
+
+    window.location(this.props.to);
+  }
+
   render() {
     return (
-      <Link className={styles.navItem} to={this.props.to}>
+      <Link className={styles.navItem} to={this.props.to} onClick={this.handleClick}>
         {this.props.text}
       </Link>
     );
@@ -14,8 +30,13 @@ class NavItem extends PureComponent {
 }
 
 NavItem.propTypes = {
+  isExternal: PropTypes.bool,
   to: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired
+};
+
+NavItem.defaultProps = {
+  isExternal: false
 };
 
 export default NavItem;


### PR DESCRIPTION
closes #31 

* Links directly to the Operation Code DonorBox page from the 'Donate Now' button midway down the page
* Added `isExternal` boolean prop that is passed to to the NavItem component from its parent. If this prop is passed in (setting `this.props.isExternal` to true, and it defaults to false if not passed in), clicking on the NavItem will call a click handler method that navigates the browser window to the external URL (`this.props.to`, also passed in from parent).  This is required to navigate to an external URL when using the React Router Link component for the NavItems, because the React Router only handles navigation for internal routes. 

