### PR TITLE
Add slide-out drawer menu for top nav on smaller widths - issue #54

### DIFF
--- a/src/scenes/home/header/burger/burger.js
+++ b/src/scenes/home/header/burger/burger.js
@@ -1,16 +1,25 @@
-import React, { Component } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import burger from 'images/icons/menu.svg';
 import styles from './burger.css';
 
-class Burger extends Component {
-  render() {
-    return (
-      <div className={styles.burger} >
-        <a className="burger" href="/"><img src={burger} alt="" /></a>
-      </div>
-    );
-  }
-}
+const Burger = (props) => {
+  const { onClick } = props;
 
+  const handleClick = (e) => {
+    e.preventDefault();
+    onClick();
+  };
+
+  return (
+    <div className={styles.burger}>
+      <a className="burger" href="/" onClick={handleClick}><img src={burger} alt="" /></a>
+    </div>
+  );
+};
+
+Burger.propTypes = {
+  onClick: PropTypes.func.isRequired
+};
 
 export default Burger;

--- a/src/scenes/home/header/header.css
+++ b/src/scenes/home/header/header.css
@@ -1,33 +1,16 @@
-
 .header {
   display: flex;
+  align-items: center;
   height: 80px;
-  align-items: center;
 }
+
 .logo {
-  height: 60px;
-  flex: 1 40%;
-  margin-left: 40px;
+  display: flex;
   align-items: center;
-  display: flex;
+  height: 60px;
+  margin-left: 40px;
 }
-.nav {
-  display: flex;
-  justify-content: space-between;
-  flex: 1 60%;
-  margin-right:8vw;
-}
-.nav a {
-  text-decoration: none;
-  color: #F7F7F7;
-  font-size: 16px;
-}
+
 .logo img {
   height: 50px;
 }
-
-/*@media screen and (max-width: 768px) {
-  .logo {
-    margin: 0 auto;
-  }
-}*/

--- a/src/scenes/home/header/header.js
+++ b/src/scenes/home/header/header.js
@@ -25,7 +25,7 @@ class Header extends Component {
         <Logo />
         <Burger onClick={this.toggleDrawer} />
         <TopNav />
-        <SideNav isVisible={this.state.isSideNavVisible} />
+        <SideNav isVisible={this.state.isSideNavVisible} onClose={this.toggleDrawer} />
       </div>
     );
   }

--- a/src/scenes/home/header/header.js
+++ b/src/scenes/home/header/header.js
@@ -1,16 +1,32 @@
 import React, { Component } from 'react';
+import Drawer from 'shared/components/drawer/drawer';
 import styles from './header.css';
 import TopNav from './topNav/topNav';
 import Logo from './logo/logo';
 import Burger from './burger/burger';
 
 class Header extends Component {
+
+  constructor() {
+    super();
+    this.state = {
+      showDrawer: false
+    };
+    this.toggleDrawer = this.toggleDrawer.bind(this);
+  }
+
+  toggleDrawer() {
+    this.setState({ showDrawer: !this.state.showDrawer });
+  }
+
   render() {
     return (
       <div className={styles.header} >
         <Logo />
         <Burger />
         <TopNav />
+        <Drawer isVisible={this.state.showDrawer} />
+        <button onClick={this.toggleDrawer}>Click</button>
       </div>
     );
   }

--- a/src/scenes/home/header/header.js
+++ b/src/scenes/home/header/header.js
@@ -10,23 +10,22 @@ class Header extends Component {
   constructor() {
     super();
     this.state = {
-      showDrawer: false
+      isSideNavVisible: false
     };
     this.toggleDrawer = this.toggleDrawer.bind(this);
   }
 
   toggleDrawer() {
-    this.setState({ showDrawer: !this.state.showDrawer });
+    this.setState({ isSideNavVisible: !this.state.isSideNavVisible });
   }
 
   render() {
     return (
       <div className={styles.header} >
         <Logo />
-        <Burger />
+        <Burger onClick={this.toggleDrawer} />
         <TopNav />
-        <SideNav isVisible={this.state.showDrawer} />
-        <button onClick={this.toggleDrawer}>Click</button>
+        <SideNav isVisible={this.state.isSideNavVisible} />
       </div>
     );
   }

--- a/src/scenes/home/header/header.js
+++ b/src/scenes/home/header/header.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import Drawer from 'shared/components/drawer/drawer';
 import styles from './header.css';
 import TopNav from './topNav/topNav';
+import SideNav from './sideNav/sideNav';
 import Logo from './logo/logo';
 import Burger from './burger/burger';
 
@@ -25,7 +25,7 @@ class Header extends Component {
         <Logo />
         <Burger />
         <TopNav />
-        <Drawer isVisible={this.state.showDrawer} />
+        <SideNav isVisible={this.state.showDrawer} />
         <button onClick={this.toggleDrawer}>Click</button>
       </div>
     );

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -1,6 +1,30 @@
+.content {
+  padding: 16px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+}
+
+.close {
+  color: #fff;
+  font-size: 20px;
+}
+
+.logo {
+  margin: 16px auto;
+  max-width: 75%;
+  max-height: 40px;
+  width: auto;
+  height: auto;
+}
+
 .list {
   display: flex;
   flex-direction: column;
+  margin-top: 8px;
+  padding: 16px;
 }
 
 .item {

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -9,7 +9,9 @@
 
 .close {
   color: #fff;
-  font-size: 20px;
+  font-size: 26px;
+  padding: 6px; /*to increase clickability on mobile*/
+  text-decoration: none;
 }
 
 .logo {

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -14,6 +14,10 @@
   text-decoration: none;
 }
 
+.logoWrapper {
+  text-align: center;
+}
+
 .logo {
   margin: 16px auto;
   max-width: 75%;

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -1,0 +1,13 @@
+.list {
+  display: flex;
+  flex-direction: column;
+}
+
+.item {
+  color: #F7F7F7;
+  font-size: 60px;
+}
+
+.item ~ .item {
+  margin-top: 16px;
+}

--- a/src/scenes/home/header/sideNav/sideNav.js
+++ b/src/scenes/home/header/sideNav/sideNav.js
@@ -1,37 +1,43 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Drawer from 'shared/components/drawer/drawer';
 import NavItem from 'shared/components/nav/navItem/navItem';
 import PropTypes from 'prop-types';
 import logo from 'images/logos/small-white-logo.png';
 import styles from './sideNav.css';
 
-class SideNav extends Component {
-  render() {
-    return (
-      <Drawer isVisible={this.props.isVisible}>
-        <div className={styles.content}>
-          <div className={styles.header}>
-            <span className={styles.close}>&#10006;</span>
-            <img className={styles.logo} src={logo} alt="Operation Code logo" />
-          </div>
-          <div className={styles.list}>
-            <NavItem className="menuItem" to="https://donorbox.org/operationcode" text="Donate" isExternal />
-            <NavItem className="menuItem" to="join" text="Join" />
-            <NavItem className="menuItem" notClickable to="about" text="About" />
-            <NavItem className="menuItem" notClickable to="programs" text="Programs" />
-            <NavItem className="menuItem" notClickable to="involved" text="Get Involved" />
-            <NavItem className="menuItem" notClickable to="blog" text="Blog" />
-          </div>
+const SideNav = (props) => {
+  const { isVisible, onClose } = props;
+
+  const handleCloseClick = (e) => {
+    e.preventDefault();
+    onClose();
+  };
+
+  return (
+    <Drawer isVisible={isVisible}>
+      <div className={styles.content}>
+        <div className={styles.header}>
+          <a className={styles.close} href="/" onClick={handleCloseClick}>&#10006;</a>
+          <img className={styles.logo} src={logo} alt="Operation Code logo" />
         </div>
+        <div className={styles.list}>
+          <NavItem className="menuItem" to="https://donorbox.org/operationcode" text="Donate" isExternal />
+          <NavItem className="menuItem" to="join" text="Join" />
+          <NavItem className="menuItem" notClickable to="about" text="About" />
+          <NavItem className="menuItem" notClickable to="programs" text="Programs" />
+          <NavItem className="menuItem" notClickable to="involved" text="Get Involved" />
+          <NavItem className="menuItem" notClickable to="blog" text="Blog" />
+        </div>
+      </div>
 
 
-      </Drawer>
-    );
-  }
-}
+    </Drawer>
+  );
+};
 
 SideNav.propTypes = {
   isVisible: PropTypes.bool,
+  onClose: PropTypes.func.isRequired
 };
 
 SideNav.defaultProps = {

--- a/src/scenes/home/header/sideNav/sideNav.js
+++ b/src/scenes/home/header/sideNav/sideNav.js
@@ -17,7 +17,9 @@ const SideNav = (props) => {
     <Drawer isVisible={isVisible}>
       <div className={styles.content}>
         <div className={styles.header}>
-          <a className={styles.close} href="/" onClick={handleCloseClick}>&#10006;</a>
+          <div>
+            <a className={styles.close} href="/" onClick={handleCloseClick}>&#10006;</a>
+          </div>
           <img className={styles.logo} src={logo} alt="Operation Code logo" />
         </div>
         <div className={styles.list}>

--- a/src/scenes/home/header/sideNav/sideNav.js
+++ b/src/scenes/home/header/sideNav/sideNav.js
@@ -2,20 +2,29 @@ import React, { Component } from 'react';
 import Drawer from 'shared/components/drawer/drawer';
 import NavItem from 'shared/components/nav/navItem/navItem';
 import PropTypes from 'prop-types';
+import logo from 'images/logos/small-white-logo.png';
 import styles from './sideNav.css';
 
 class SideNav extends Component {
   render() {
     return (
       <Drawer isVisible={this.props.isVisible}>
-        <div className={styles.list}>
-          <NavItem className="menuItem" to="https://donorbox.org/operationcode" text="Donate" isExternal />
-          <NavItem className="menuItem" to="join" text="Join" />
-          <NavItem className="menuItem" notClickable to="about" text="About" />
-          <NavItem className="menuItem" notClickable to="programs" text="Programs" />
-          <NavItem className="menuItem" notClickable to="involved" text="Get Involved" />
-          <NavItem className="menuItem" notClickable to="blog" text="Blog" />
+        <div className={styles.content}>
+          <div className={styles.header}>
+            <span className={styles.close}>&#10006;</span>
+            <img className={styles.logo} src={logo} alt="Operation Code logo" />
+          </div>
+          <div className={styles.list}>
+            <NavItem className="menuItem" to="https://donorbox.org/operationcode" text="Donate" isExternal />
+            <NavItem className="menuItem" to="join" text="Join" />
+            <NavItem className="menuItem" notClickable to="about" text="About" />
+            <NavItem className="menuItem" notClickable to="programs" text="Programs" />
+            <NavItem className="menuItem" notClickable to="involved" text="Get Involved" />
+            <NavItem className="menuItem" notClickable to="blog" text="Blog" />
+          </div>
         </div>
+
+
       </Drawer>
     );
   }

--- a/src/scenes/home/header/sideNav/sideNav.js
+++ b/src/scenes/home/header/sideNav/sideNav.js
@@ -20,15 +20,44 @@ const SideNav = (props) => {
           <div>
             <a className={styles.close} href="/" onClick={handleCloseClick}>&#10006;</a>
           </div>
-          <img className={styles.logo} src={logo} alt="Operation Code logo" />
+          <a className={styles.logoWrapper} href="/">
+            <img className={styles.logo} src={logo} alt="Operation Code logo" />
+          </a>
         </div>
         <div className={styles.list}>
-          <NavItem className="menuItem" to="https://donorbox.org/operationcode" text="Donate" isExternal />
-          <NavItem className="menuItem" to="join" text="Join" />
-          <NavItem className="menuItem" notClickable to="about" text="About" />
-          <NavItem className="menuItem" notClickable to="programs" text="Programs" />
-          <NavItem className="menuItem" notClickable to="involved" text="Get Involved" />
-          <NavItem className="menuItem" notClickable to="blog" text="Blog" />
+          <NavItem
+            className="menuItem"
+            to="https://donorbox.org/operationcode"
+            text="Donate"
+            isExternal
+            onClick={handleCloseClick}
+          />
+          <NavItem
+            className="menuItem"
+            to="join" text="Join"
+            onClick={handleCloseClick}
+          />
+          <NavItem
+            className="menuItem"
+            notClickable to="about"
+            text="About" onClick={handleCloseClick}
+          />
+          <NavItem
+            className="menuItem"
+            notClickable to="programs"
+            text="Programs" onClick={handleCloseClick}
+          />
+          <NavItem
+            className="menuItem"
+            notClickable to="involved"
+            text="Get Involved" onClick={handleCloseClick}
+          />
+          <NavItem
+            className="menuItem"
+            notClickable to="blog"
+            text="Blog"
+            onClick={handleCloseClick}
+          />
         </div>
       </div>
 

--- a/src/scenes/home/header/sideNav/sideNav.js
+++ b/src/scenes/home/header/sideNav/sideNav.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import Drawer from 'shared/components/drawer/drawer';
+import NavItem from 'shared/components/nav/navItem/navItem';
+import PropTypes from 'prop-types';
+import styles from './sideNav.css';
+
+class SideNav extends Component {
+  render() {
+    return (
+      <Drawer isVisible={this.props.isVisible}>
+        <div className={styles.list}>
+          <NavItem className="menuItem" to="https://donorbox.org/operationcode" text="Donate" isExternal />
+          <NavItem className="menuItem" to="join" text="Join" />
+          <NavItem className="menuItem" notClickable to="about" text="About" />
+          <NavItem className="menuItem" notClickable to="programs" text="Programs" />
+          <NavItem className="menuItem" notClickable to="involved" text="Get Involved" />
+          <NavItem className="menuItem" notClickable to="blog" text="Blog" />
+        </div>
+      </Drawer>
+    );
+  }
+}
+
+SideNav.propTypes = {
+  isVisible: PropTypes.bool,
+};
+
+SideNav.defaultProps = {
+  isVisible: false,
+};
+
+export default SideNav;

--- a/src/shared/components/drawer/drawer.css
+++ b/src/shared/components/drawer/drawer.css
@@ -5,6 +5,7 @@
   bottom: 0;
   overflow: hidden;
   width: 320px;
+  z-index: 2;
   transition: left .25s ease-in-out;
 }
 

--- a/src/shared/components/drawer/drawer.css
+++ b/src/shared/components/drawer/drawer.css
@@ -1,0 +1,39 @@
+.body {
+  display: none;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  overflow: hidden;
+  width: 320px;
+  transition: left .25s ease-in-out;
+}
+
+.hidden {
+  composes: body;
+  left: -100%;
+}
+
+.visible {
+  composes: body;
+  left: 0;
+}
+
+.content {
+  background-color: #4A4A4A;
+  height: 100%;
+  width: 100%;
+}
+
+
+@media screen and (max-width: 760px) /* Tablet */ {
+  .body {
+    display: block;
+    width: 480px;
+  }
+}
+
+@media screen and (max-width: 480px) /* Tablet */ {
+  .body {
+    width: 100%;
+  }
+}

--- a/src/shared/components/drawer/drawer.js
+++ b/src/shared/components/drawer/drawer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styles from './drawer.css';
 
 const Drawer = (props) => {
-  const { isVisible } = props;
+  const { isVisible, children } = props;
   let className = styles.hidden;
 
   if (isVisible) {
@@ -12,17 +12,20 @@ const Drawer = (props) => {
 
   return (
     <div className={className}>
-      <div className={styles.content} />
+      <div className={styles.content}>
+        {children}
+      </div>
     </div>
   );
 };
 
 Drawer.propTypes = {
-  isVisible: PropTypes.bool
+  isVisible: PropTypes.bool,
+  children: PropTypes.arrayOf(PropTypes.element).isRequired
 };
 
 Drawer.defaultProps = {
-  isVisible: false
+  isVisible: false,
 };
 
 export default Drawer;

--- a/src/shared/components/drawer/drawer.js
+++ b/src/shared/components/drawer/drawer.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './drawer.css';
+
+const Drawer = (props) => {
+  const { isVisible } = props;
+  let className = styles.hidden;
+
+  if (isVisible) {
+    className = styles.visible;
+  }
+
+  return (
+    <div className={className}>
+      <div className={styles.content} />
+    </div>
+  );
+};
+
+Drawer.propTypes = {
+  isVisible: PropTypes.bool
+};
+
+Drawer.defaultProps = {
+  isVisible: false
+};
+
+export default Drawer;

--- a/src/shared/components/nav/navItem/navItem.css
+++ b/src/shared/components/nav/navItem/navItem.css
@@ -3,6 +3,15 @@
   color: #F7F7F7;
 }
 
+.menuItem {
+  composes: navItem;
+  font-size: 30px;
+}
+
+.menuItem ~ .menuItem {
+  margin-top: 16px;
+}
+
 .disabledNavItem {
   visibility: hidden;
 }

--- a/src/shared/components/nav/navItem/navItem.js
+++ b/src/shared/components/nav/navItem/navItem.js
@@ -14,11 +14,13 @@ class NavItem extends PureComponent {
   }
 
   handleClick() {
-    if (!this.props.isExternal) {
-      return;
+    if (this.props.isExternal) {
+      window.location(this.props.to);
     }
 
-    window.location(this.props.to);
+    if (this.props.onClick) {
+      this.props.onClick();
+    }
   }
 
   render() {
@@ -36,6 +38,7 @@ NavItem.propTypes = {
   className: PropTypes.string,
   isExternal: PropTypes.bool,
   notClickable: PropTypes.bool,
+  onClick: PropTypes.func,
   to: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired
 };
@@ -43,7 +46,8 @@ NavItem.propTypes = {
 NavItem.defaultProps = {
   className: null,
   isExternal: false,
-  notClickable: false
+  notClickable: false,
+  onClick: null
 };
 
 // TODO: Remove all references to notClickable and disabledClass (including .css) when

--- a/src/shared/components/nav/navItem/navItem.js
+++ b/src/shared/components/nav/navItem/navItem.js
@@ -8,7 +8,8 @@ class NavItem extends PureComponent {
   constructor() {
     super();
 
-    // remove this if .eslintrc updated to parser:"babel-eslint", allowing class methods as => fns
+    // TODO: remove this if .eslintrc updated to parser:"babel-eslint",
+    // allowing class methods as => fns
     this.handleClick = this.handleClick.bind(this);
   }
 
@@ -21,10 +22,10 @@ class NavItem extends PureComponent {
   }
 
   render() {
-    const disabledClass = this.props.notClickable ? styles.disabledNavItem : styles.navItem;
-
+    const disabledClass = this.props.notClickable ? styles.disabledNavItem : '';
+    const classes = `${styles.navItem} ${disabledClass} ${styles[this.props.className]}`;
     return (
-      <Link className={disabledClass} to={this.props.to} onClick={this.handleClick}>
+      <Link className={classes} to={this.props.to} onClick={this.handleClick}>
         {this.props.text}
       </Link>
     );
@@ -32,6 +33,7 @@ class NavItem extends PureComponent {
 }
 
 NavItem.propTypes = {
+  className: PropTypes.string,
   isExternal: PropTypes.bool,
   notClickable: PropTypes.bool,
   to: PropTypes.string.isRequired,
@@ -39,6 +41,7 @@ NavItem.propTypes = {
 };
 
 NavItem.defaultProps = {
+  className: null,
   isExternal: false,
   notClickable: false
 };


### PR DESCRIPTION
closes #54

At screen widths < 760px, when clicking on the Burger component in the top-right, a menu w. nav links will slide out from the left side.

Future TODOs:
* Add a prop to the Drawer component, specifying whether to slide out from either left or right side of screen (currently hardcoded to always slide from left)
* Instead of using `position: absolute` and top/left/right/bottom positioning, use CSS 2D transforms and translate() for better performance - see [article](https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/) by @paulirish
* Prevent user from scrolling down vertically when the nav menu drawer is open (you can currently do this - somewhat of a bug)