### PR TITLE
Add mobile styling adjustments - issue #67

### DIFF
--- a/src/scenes/home/header/burger/burger.css
+++ b/src/scenes/home/header/burger/burger.css
@@ -14,8 +14,6 @@
     right: 0;
     margin: 0;
     margin-right: 7px;
-    border: 1px white solid;
-    border-radius: 3px;
     padding: 0 4px 0 4px;
   }
 }

--- a/src/scenes/home/home.css
+++ b/src/scenes/home/home.css
@@ -18,3 +18,11 @@
     background-size: 100%;
     background-repeat: no-repeat;
 }
+
+@media screen and (max-width: 599px) {
+  .backgroundImage {
+    background-size: 600px auto;
+    background-position: center 0;
+    background-attachment: fixed;
+  }
+}

--- a/src/scenes/home/landing/landing.css
+++ b/src/scenes/home/landing/landing.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   flex: 1 0 100%;
   align-items: center;
+  width: 100%;
 }
 
 .pageHeading {


### PR DESCRIPTION
Fixes #67 

* Horizontally centered landing page content at screen widths < 400px
* Adjusted scaling of background image to cover landing page header (no more white space behind the Join button)
* Removed white border from burger icon (this one is up for debate, but IMO it looks cleaner this way - the border appeared slightly off-center to me & had more vertical space at the bottom than the top)