### PR TITLE
Only check for production mode for GA. Fixes #143

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,8 +11,8 @@ class App extends Component {
   }
 
   componentDidMount() {
-    if (process.env.NODE_ENV === 'production' && process.env.GA_TRACKER_ID) {
-      ReactGA.initialize(process.env.GA_TRACKER_ID);
+    if (process.env.NODE_ENV === 'production') {
+      ReactGA.initialize('UA-75642413-1', { debug: false });
       this.history.listen((location) => {
         ReactGA.set({ page: location.pathname });
         ReactGA.pageview(location.pathname);


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
I suspect that the GA ID is never being set so lets just check for production mode and set it statically for now.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #143
