### PR TITLE
Issue #69 fixed heading font-size, border-style for mobile < 321px

### DIFF
--- a/src/scenes/home/signup/signup.css
+++ b/src/scenes/home/signup/signup.css
@@ -39,10 +39,17 @@
     border: 1px solid rgb(92,105,122);
     padding: 10px;
   }
-}
-
-@media screen and (max-width: 599px) {
   .signup h2 {
     font-size: 26px;
+  }
+}
+
+@media screen and (max-width: 321px) {
+  .signupForm {
+    border-left-style: none;
+    border-right-style: none;
+  }
+  .signup h2 {
+    font-size: 20px;
   }
 }


### PR DESCRIPTION
# Description of changes
Reduced font-size on heading so that it does not wrap and cause visual errors. Also removed the left and right border on smaller device screen to make it more appealing. The button was full-width and did not need to be centered.

# Issue Resolved
Fixes #69
