### PR TITLE
Fixes responsive header background image width

### DIFF
--- a/src/scenes/home/home.css
+++ b/src/scenes/home/home.css
@@ -22,7 +22,7 @@
 
 @media screen and (max-width: 760px) {
   .backgroundImage {
-    background-size: auto 50%;
+    background-size: auto 75%;
     background-attachment: fixed;
   }
 }


### PR DESCRIPTION
Expanded the width of the header background image so it fills in the blank margin at the 760px media query.

# Description of changes
Improves upon #133

# Issue Resolved
Fixes #133
