### PR TITLE
Resolve #204 - Add Heap Analytics to evaluate Integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 
         <link rel="stylesheet" type="styles/css" href="styles/css/styles.css">
         <script src="https://cdn.ravenjs.com/3.16.0/raven.min.js" crossorigin="anonymous"></script>
+        <script type="text/javascript"> window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])}; heap.load("405779510"); </script>
     </head>
 
     <body>


### PR DESCRIPTION
# Description of changes
Adding Heap Analytics gives us additional and alternative information to Google analytics on how our website is being used.

# Issue Resolved

Fixes #204 
