### PR TITLE
Mobile menu fix (sideNav)

### DIFF
--- a/src/scenes/home/header/burger/burger.css
+++ b/src/scenes/home/header/burger/burger.css
@@ -3,7 +3,7 @@
 }
 
 .burger img {
-  width: 2.5em;
+  width: 1em;
   margin: 0;
   background-color: #fafafa;
   padding: 10px;
@@ -18,6 +18,6 @@
     display: block;
     position: absolute;
     right: 5%;
-    top: 15px;
+    top: 20px;
   }
 }

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -38,7 +38,7 @@
   display: flex;
   flex-direction: column;
   margin-top: 80px;
-  padding: 50px 5%;
+  padding: 30px 5%;
   border-top: 1px solid #fafafa;
   font-size: 40px;
 }

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -66,5 +66,14 @@
   text-align: left;
   font-size: 2.5rem;
   margin: 0.5rem 0;
-  padding: 0; 
+  padding: 0;
+}
+
+@media screen and (orientation: landscape) {
+  .content {
+    position: absolute;
+  }
+  .list {
+    font-size: 20px;
+  }
 }

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -40,7 +40,7 @@
   margin-top: 80px;
   padding: 30px 5%;
   border-top: 1px solid #fafafa;
-  font-size: 40px;
+  font-size: 2.5em;
 }
 
 .item {
@@ -74,6 +74,6 @@
     position: absolute;
   }
   .list {
-    font-size: 20px;
+    font-size: 1.3em;
   }
 }

--- a/src/scenes/home/header/sideNav/sideNav.js
+++ b/src/scenes/home/header/sideNav/sideNav.js
@@ -46,12 +46,10 @@ class SideNav extends Component {
       );
     }
     return (
-      <span>
-        <NavItem
-          to="/join" text="Join"
-          onClick={this.handleCloseClick}
-        />
-      </span>
+      <NavItem
+        to="/join" text="Join"
+        onClick={this.handleCloseClick}
+      />
     );
   }
 
@@ -69,6 +67,7 @@ class SideNav extends Component {
             </a>
           </div>
           <div className={styles.list}>
+            {this.renderNavItems()}
             <NavItem
               to="code_schools"
               text="Code Schools"
@@ -80,7 +79,6 @@ class SideNav extends Component {
               isExternal
               onClick={this.handleCloseClick}
             />
-            {this.renderNavItems()}
             <NavItem
               to="about"
               text="About"

--- a/src/scenes/home/header/sideNav/sideNav.js
+++ b/src/scenes/home/header/sideNav/sideNav.js
@@ -47,7 +47,8 @@ class SideNav extends Component {
     }
     return (
       <NavItem
-        to="/join" text="Join"
+        to="/join"
+        text="Join"
         onClick={this.handleCloseClick}
       />
     );


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Fixes display issues of the sideNav and hamburger on mobile devices by restructuring sideNav's rendering of links, reducing hamburger size, and adding a landscape media query. This fix will work for now, but as soon as our login system is operational, sideNav will attempt to render a lot more links. We will need some work to fix this when the login system works 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Works towards fixing #239 #238 by correcting te mobile menu issues seen in screenshots of both those issues. 
