### PR TITLE
Section Children Styling Fix

### DIFF
--- a/src/scenes/home/codeSchools/codeSchools.css
+++ b/src/scenes/home/codeSchools/codeSchools.css
@@ -10,11 +10,3 @@
 .filterButtonDiv > a {
   margin: 2% 1%;
 }
-
-.leadingParagraph {
-	font-size: 2rem;
-}
-
-.secondParagraph {
-	font-size: 1.4rem;
-}

--- a/src/scenes/home/codeSchools/codeSchools.js
+++ b/src/scenes/home/codeSchools/codeSchools.js
@@ -32,10 +32,7 @@ class CodeSchools extends Component {
           theme="white"
           margin
         >
-          <p className={styles.leadingParagraph}>
-            Code schools prepare aspiring programmers for new careers in software development.
-          </p>
-          <p className={styles.secondParagraph}>
+          <p>
             Code schools are accelerated learning programs that will prepare you for a career in
             software development. <br />Each school listed below ranges in length, vary in tuition costs,
             and in programming languages. <br />Desirable from an employer&apos;s standpoint, code schools

--- a/src/scenes/home/codeSchools/onlineSchools/onlineSchools.css
+++ b/src/scenes/home/codeSchools/onlineSchools/onlineSchools.css
@@ -1,16 +1,8 @@
-.intro {
-  padding: 0 0 2.5% 0;
-}
-
 .eSchools {
   display: flex;
   flex-flow: row wrap;
   align-items: center;
   justify-content: space-around;
-}
-
-.moocs {
-  padding: 2.5% 0 2.5% 0;
 }
 
 /* CodeClimate didn't like .moocs > h3 */
@@ -24,10 +16,6 @@
   flex-flow: column;
   align-items: center;
   justify-content: space-around;
-}
-
-.leadingParagraph {
-  font-size: 1.4rem;
 }
 
 .boxShadow {

--- a/src/scenes/home/codeSchools/onlineSchools/onlineSchools.js
+++ b/src/scenes/home/codeSchools/onlineSchools/onlineSchools.js
@@ -52,26 +52,28 @@ class OnlineSchools extends Component {
       )
     );
     return (
-      <Section
-        id="onlineSchools"
-        title="Online Schools"
-        headingLines={false}
-        margin
-      >
-        <div className={styles.intro}>
-          <p className={styles.leadingParagraph}>
+      <div>
+        <Section
+          id="onlineSchools"
+          title="Online Schools"
+          headingLines={false}
+        >
+          <p>
             Many programs offer coding schools in a completely digital fashion. <br />Regardless of where
             you are in the world, you can learn how to code through these programs!
           </p>
-        </div>
 
-        <div className={styles.eSchools}>
-          {eSchools}
-        </div>
+          <div className={styles.eSchools}>
+            {eSchools}
+          </div>
+        </Section>
 
-        <div className={styles.moocs}>
-          <h3>MOOCs</h3>
-          <p className={styles.leadingParagraph}>
+        <Section
+          id="moocSchools"
+          title="MOOCs"
+          headingLines={false}
+        >
+          <p>
             Massive, Open, Online Courses (or MOOCs) are course study programs made available over
             the internet!
             <br />
@@ -105,8 +107,8 @@ class OnlineSchools extends Component {
               link={'https://udacity.org/'}
             />
           </div>
-        </div>
-      </Section>
+        </Section>
+      </div>
     );
   }
 }

--- a/src/scenes/home/codeSchools/partnerSchools/partnerSchools.css
+++ b/src/scenes/home/codeSchools/partnerSchools/partnerSchools.css
@@ -14,7 +14,3 @@
   font-size: 1em;
   margin: 15px 0 0 0;
 }
-
-.introParagraph {
-	font-size: 1.4rem;
-}

--- a/src/scenes/home/codeSchools/partnerSchools/partnerSchools.js
+++ b/src/scenes/home/codeSchools/partnerSchools/partnerSchools.js
@@ -21,15 +21,15 @@ class PartnerSchools extends Component {
         headingLines={false}
         margin
       >
-        <div className={styles.intro}>
-          <p className={styles.introParagraph}>
-            Many code schools around the nation offer military/veterans discounts to make coding
-            education more accessible to our veterans.<br />
-            We&apos;ve partnered up with those schools in order to help direct veterans to the best
-            code schools around the country. <br /> <b>Apply for a scholarship with our partners now and
-            get coding:</b>
-          </p>
-        </div>
+        <p>
+          Many code schools around the nation offer military/veterans discounts to make coding education more accessible to our veterans.
+          <br />
+          We&apos;ve partnered up with those schools in order to help direct veterans to the best code schools around the country.
+          <br />
+          <br />
+          <b>Apply for a scholarship with our partners now and get coding:</b>
+        </p>
+
 
         <div className={styles.partnerSchools}>
           <SchoolCard

--- a/src/scenes/home/team/team.css
+++ b/src/scenes/home/team/team.css
@@ -1,7 +1,7 @@
 .team {
   display: flex;
   flex-wrap: wrap;
-  padding: 20px 40px;
+  padding: 20px 0;
   align-items: center;
   justify-content: center;
 }
@@ -9,10 +9,9 @@
 .board {
   display: flex;
   flex-wrap: wrap;
-  padding: 20px 40px;
+  padding: 20px 0;
   align-items: center;
   justify-content: center;
-  margin-bottom: 170px;
 }
 
 @media screen and (max-width: 1200px) {

--- a/src/scenes/home/team/team.css
+++ b/src/scenes/home/team/team.css
@@ -14,20 +14,3 @@
   justify-content: center;
 }
 
-@media screen and (max-width: 1200px) {
-  .board {
-    margin-bottom: 75px;
-  }
-}
-
-@media screen and (max-width: 850px) {
-  .board {
-    margin-bottom: 50px;
-  }
-}
-
-@media screen and (max-width: 800px) {
-  .board {
-    margin-bottom: 25px;
-  }
-}

--- a/src/scenes/home/team/team.js
+++ b/src/scenes/home/team/team.js
@@ -57,7 +57,7 @@ class Team extends Component {
         />
 
         <Section title="Our Team" theme="white">
-          <p className={styles.paragraph}>
+          <p>
             Our all volunteer staff are dedicated individuals who come from a wide variety of backgrounds, including U.S Military Veterans, civilians, those with tech backgrounds, and those who have skills outside of web development.
           </p>
           <div className={styles.team}>
@@ -66,9 +66,6 @@ class Team extends Component {
         </Section>
 
         <Section title="Our Board" theme="gray">
-          <p className={styles.paragraph}>
-            Our fearless volunteer leaders. No salaries here.
-          </p>
           <div className={styles.board}>
             <StaffCard name={founder.name} role={founder.role} src={founder.src} twitter={founder.twitter} email={founder.email} alt={founder.alt} />
             <StaffCard name={coo.name} role={coo.role} src={coo.src} twitter={coo.twitter} email={coo.email} alt={coo.alt} />


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Changes code schools and team pages to remove the paragraph and section styling that was universally fixed upon #230 merge. This leads the way to the final push for responsiveness where I can go in to solve individual page problems. 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Removes redundant section styling after #230 merge.
