### PR TITLE
Faq mobile fix

### DIFF
--- a/src/scenes/home/faq/faq.css
+++ b/src/scenes/home/faq/faq.css
@@ -1,21 +1,6 @@
 .container {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
-}
-
-.accordion {
-  line-height: 1.5;
-  max-width: 80%;
-}
-
-.paragraph {
-  font-size: 1.5rem;
-}
-
-.headline {
-  font-size: 1.7rem;
-  font-weight: 800rem;
-  margin: 2rem 0;
 }

--- a/src/scenes/home/faq/faq.js
+++ b/src/scenes/home/faq/faq.js
@@ -13,6 +13,7 @@ class FAQ extends Component {
           <Question
             q={question.question}
             a={question.answer}
+            key={Math.random + question.question}
           />
         )
     );
@@ -22,6 +23,7 @@ class FAQ extends Component {
           <Question
             q={question.question}
             a={question.answer}
+            key={Math.random + question.question}
           />
         )
     );
@@ -31,12 +33,13 @@ class FAQ extends Component {
           <Question
             q={question.question}
             a={question.answer}
+            key={Math.random + question.question}
           />
         )
     );
 
     return (
-      <Section title="Frequently Asked Questions" theme="white">
+      <Section title="General Questions" theme="white">
         <Section theme="white" headingLines={false}>
           <div className={styles.container}>
             {generalQuestions}

--- a/src/scenes/home/faq/faq.js
+++ b/src/scenes/home/faq/faq.js
@@ -3,6 +3,7 @@ import LinkButton from 'shared/components/linkButton/linkButton';
 import Section from 'shared/components/section/section';
 import Question from './question/question';
 import Data from './questions.json';
+import styles from './faq.css';
 
 class FAQ extends Component {
   render() {
@@ -35,9 +36,12 @@ class FAQ extends Component {
     );
 
     return (
-      <Section title="Frequently Asked Questions" theme="white" headingLines={false}>
+      <Section title="Frequently Asked Questions" theme="white">
         <Section theme="white" headingLines={false}>
-          {generalQuestions}
+          <div className={styles.container}>
+            {generalQuestions}
+          </div>
+          <br />
           <LinkButton
             link="top"
             text="Scroll to Top"
@@ -45,8 +49,12 @@ class FAQ extends Component {
             scrollLink
           />
         </Section>
-        <Section title="Donation Questions" theme="white" headingLines={false}>
-          {donationQuestions}
+        <Section title="Donation Questions" theme="white">
+          <br />
+          <div className={styles.container}>
+            {donationQuestions}
+          </div>
+          <br />
           <LinkButton
             link="top"
             text="Scroll to Top"
@@ -54,8 +62,11 @@ class FAQ extends Component {
             scrollLink
           />
         </Section>
-        <Section title="Volunteer Questions" theme="white" headingLines={false}>
-          {volunteerQuestions}
+        <Section title="Volunteer Questions" theme="white">
+          <br />
+          <div className={styles.container}>
+            {volunteerQuestions}
+          </div>
         </Section>
       </Section>
     );

--- a/src/scenes/home/faq/faq.js
+++ b/src/scenes/home/faq/faq.js
@@ -3,7 +3,6 @@ import LinkButton from 'shared/components/linkButton/linkButton';
 import Section from 'shared/components/section/section';
 import Question from './question/question';
 import Data from './questions.json';
-import styles from './faq.css';
 
 class FAQ extends Component {
   render() {
@@ -36,40 +35,29 @@ class FAQ extends Component {
     );
 
     return (
-      <div>
-        <Section title="Frequently Asked Questions" theme="white">
-          <span id="top" className={styles.headline}>General Questions</span>
-          <div className={styles.container}>
-            <div className={styles.accordion}>
-              {generalQuestions}
-            </div>
-          </div>
+      <Section title="Frequently Asked Questions" theme="white" headingLines={false}>
+        <Section theme="white" headingLines={false}>
+          {generalQuestions}
           <LinkButton
             link="top"
             text="Scroll to Top"
             theme="blue"
             scrollLink
           />
-          <span className={styles.headline}>Donation Questions</span>
-          <div className={styles.container}>
-            <div className={styles.accordion}>
-              {donationQuestions}
-            </div>
-          </div>
-          <LinkButton
-            link="top"
-            text="Scroll to Top"
-            theme="blue"
-            scrollLink
-          />
-          <span className={styles.headline}>Volunteer Questions</span>
-          <div className={styles.container}>
-            <div className={styles.accordion}>
-              {volunteerQuestions}
-            </div>
-          </div>
         </Section>
-      </div>
+        <Section title="Donation Questions" theme="white" headingLines={false}>
+          {donationQuestions}
+          <LinkButton
+            link="top"
+            text="Scroll to Top"
+            theme="blue"
+            scrollLink
+          />
+        </Section>
+        <Section title="Volunteer Questions" theme="white" headingLines={false}>
+          {volunteerQuestions}
+        </Section>
+      </Section>
     );
   }
 }

--- a/src/scenes/home/faq/question/question.css
+++ b/src/scenes/home/faq/question/question.css
@@ -22,7 +22,11 @@
 }
 
 .accordionSingle {
-  padding: 1rem;
+  border: 1px solid #c5c5c5;
+  padding: 20px;
+  border-radius: 5px;
+  margin-bottom: 10px;
+  width: 100%;
 }
 
 .accordionSingleQuestion {

--- a/src/scenes/home/faq/question/question.css
+++ b/src/scenes/home/faq/question/question.css
@@ -3,11 +3,8 @@
 }
 
 .accordionSingleHidden:checked ~ .accordionSingleAnswer {
-  max-height: 400px;
+  max-height: 600px;
   opacity: 1;
-  -webkit-transform: translate(0, 0);
-      -ms-transform: translate(0, 0);
-          transform: translate(0, 0);
   margin-top: 14px;
 }
 
@@ -19,20 +16,17 @@
   margin-top: 0;
   max-height: 0;
   opacity: 0;
-  transform: translate(0, 50%);
+  transform: translate(0, 5%);
   transition: all .4s ease;
   position: relative;
 }
 
 .accordionSingle {
-  margin-bottom: 30px;
-  background: lightgray;
-  padding: 1.5rem;
+  padding: 1rem;
 }
 
 .accordionSingleQuestion {
   font-weight: 600;
-  letter-spacing: 1px;
   text-transform: uppercase;
   cursor: pointer;
   position: relative;
@@ -51,4 +45,16 @@
 
 .accordionSingleAnswer {
   margin-top: 5px;
+}
+
+@media screen and (max-width: 800px){
+  .accordionSingle{
+    max-width: 270px;
+  }
+}
+
+@media screen and (max-width: 550px) {
+  .accordionSingle {
+    max-width: 200px;
+  }
 }

--- a/src/shared/components/heading/heading.css
+++ b/src/shared/components/heading/heading.css
@@ -29,3 +29,9 @@
     font-size: 1.8em;
   }
 }
+
+@media screen and (max-width: 500px) {
+  .heading {
+    font-size: 1.5em;
+  }
+}


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Overhauls the FAQ section for responsiveness across all devices because it was previously unreadable on any mobile device. Includes a small out-of-scope header font-size media query that was necessary for the FAQ section to display properly. the media queries border on the safe side and render a bit small. 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes the FAQ section and works towards fixing #238 and #237 

### Testing
Mobile: (portrait and landscape) Iphone 5, Iphone 6, Nexus 6, Ipad Pro 
Desktop: Firefox, Safari, Chrome (across all drag widths)
