### PR TITLE
Set cookie on OC's TLD

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,7 +5,7 @@ process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
 process.env.OC_BACKEND_URL = 'https://api.operationcode.org/api/v1';
 process.env.OC_IDME_CLIENT_ID = '6d781bfd42506613a0fe4ad4123aaf6d';
-process.env.OC_HOST = 'https://www.operationcode.org',
+process.env.OC_HOST = 'https://operationcode.org',
 process.env.OC_IDME_AUTH_URL = 'https://api.id.me/oauth/authorize'
 
 // Makes the script crash on unhandled rejections instead of silently

--- a/src/shared/utils/cookieHelper.js
+++ b/src/shared/utils/cookieHelper.js
@@ -2,7 +2,7 @@ import Cookies from 'universal-cookie';
 
 export const setUserAuthCookie = ({ token, user }) => {
   const cookies = new Cookies();
-  cookies.set('token', token, { path: '/' });
+  cookies.set('token', token, { path: '/', domain: 'operationcode.org' });
   cookies.set('firstName', user.first_name, { path: '/' });
   cookies.set('lastName', user.last_name, { path: '/' });
   cookies.set('slackName', user.slack_name, { path: '/' });


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Explicity sets the cookie domain, redirects ID.me verifications back to oc.org, not www.oc.org

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #266 
