### PR TITLE
Adds link to OC backend API endpoint documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,6 +283,7 @@ Now that you understand the technology and project structure, feel free to direc
 - `docker-compose up -d --build` - Builds and starts the Docker Container listening port 80.
 
 ## Resources
+- [Operation Code Backend API Endpoints](http://docs.operationcodeapi.apiary.io/#)
 - [Learning React With Create-React-App](https://medium.com/@diamondgfx/learning-react-with-create-react-app-part-1-a12e1833fdc)
 - [What Is Webpack?](https://survivejs.com/webpack/what-is-webpack/)
 - [Routed React with Express.js and Docker](https://medium.com/@patriciolpezjuri/using-create-react-app-with-react-router-express-js-8fa658bf892d)


### PR DESCRIPTION
# Description of changes
Adds a link to our [backend apiary API docs](http://docs.operationcodeapi.apiary.io/#) so that our contributors can reference them when needed.

# Issue Resolved
Fixes #288 
