### PR TITLE
Resolve #75

### DIFF
--- a/src/shared/components/form/formInput/formInput.css
+++ b/src/shared/components/form/formInput/formInput.css
@@ -5,3 +5,17 @@
 .formInput > input::placeholder {
   color: #999;
 }
+
+.formInput > .error {
+  border-style: solid;
+  border-width: 1px;
+  border-color: #D1665A;
+}
+
+.formInput > span {
+  color: #D1665A;
+}
+
+.formInput > input:focus {
+  border-style: none;
+}

--- a/src/shared/components/form/formInput/formInput.js
+++ b/src/shared/components/form/formInput/formInput.js
@@ -37,6 +37,7 @@ class FormInput extends Component {
         {this.props.label && <Label htmlFor={this.props.id}>{this.props.label}</Label>}
 
         <input
+          className={!this.state.isValid && styles.error}
           id={this.props.id}
           type={this.props.inputType}
           value={this.state.text}


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
When a FormInput component's validation finds an error, its borders will turn red when it doesn't have focus (this behavior will also be exhibited by FormEmail, FormPassword, and FormZipCode components because they compose FormInput). Also, in the style of the Bootstrap forms, the error text was also changed to display in red.
# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #75
