### PR TITLE
added scrollToTop component and added it to react router

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { Route, Router } from 'react-router';
 import createHistory from 'history/createBrowserHistory';
 import ReactGA from 'react-ga';
 import Home from './scenes/home/home';
+import ScrollToTop from './shared/components/ScrollToTop';
 
 class App extends Component {
   constructor(props) {
@@ -23,7 +24,9 @@ class App extends Component {
   render() {
     return (
       <Router history={this.history} >
-        <Route path="/" component={Home} />
+        <ScrollToTop>
+          <Route path="/" component={Home} />
+        </ScrollToTop>
       </Router>
     );
   }

--- a/src/shared/components/ScrollToTop.js
+++ b/src/shared/components/ScrollToTop.js
@@ -1,0 +1,33 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+
+class ScrollToTop extends Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+ScrollToTop.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }),
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.element
+  ]).isRequired
+};
+
+ScrollToTop.defaultProps = {
+  location: {
+    pathname: '',
+  },
+};
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
# Description of changes
Able to scroll up to top after clicking footer links.
Found solution here: https://stackoverflow.com/questions/34345722/enforcing-scrolltotop-behavior-using-react-router

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #260
