### PR TITLE
Modified space between links to separate and give breathing room.

### DIFF
--- a/src/scenes/home/footer/footer.css
+++ b/src/scenes/home/footer/footer.css
@@ -155,14 +155,14 @@
   }
 
   .blockGroup {
-    font-size: 1.5rem;
+    font-size: 1rem;
   }
 
   .blockGroup a {
-    padding: 0 10px;
+    padding: 10px 10px;
   }
 
   .blockGroup ~ .blockGroup {
-    margin-top: 16px;
+    margin-top: 10px;
   }
 }


### PR DESCRIPTION
# Description of changes
I modified the padding, margin, and font-size of sub-components of the footer component to space out the links a little more and give them some breathing room. The examples I have are a before image of an iPhone 6 as well as after photos on an iPhone 6 and iPhone 5.

#### Before fixes, iPhone6
<img src="https://user-images.githubusercontent.com/6799474/28738765-73d6bb98-73c3-11e7-84d3-e31385954ee0.png" width="200">

#### After fixes, iPhone5
<img src="https://user-images.githubusercontent.com/6799474/28738771-7d7d4946-73c3-11e7-9b97-1cd809f1ab49.png" width="200">

#### After fixes, iPhone6
<img src="https://user-images.githubusercontent.com/6799474/28738777-84294a24-73c3-11e7-8950-b06b2de9500b.png" width="200">





