### PR TITLE
Fix rendering of /about/financial-statements

### DIFF
--- a/src/scenes/home/home.js
+++ b/src/scenes/home/home.js
@@ -150,6 +150,11 @@ class Home extends Component {
               component={Contact}
             />
             <Route
+              exact
+              path="/about/financial-statements"
+              component={FinancialStatements}
+            />
+            <Route
               path="/about"
               component={About}
             />
@@ -231,7 +236,6 @@ class Home extends Component {
               updateRootAuthState={this.updateRootAuthState}
               {...authProps}
             />
-            <Route exact path="/about/financial-statements" component={FinancialStatements} />
             <Route exact path="/reset_password" component={ResetPassword} />
             <Route
               path="*" component={FourOhFour}


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Changes the order of `<Route>`s in the main `<Switch>` so that /about isn't matched before /about/financial-statements
# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #71 
