### PR TITLE
Unable to deselect favorite languages during sign up

### DIFF
--- a/src/scenes/home/informationForm/formComponents/interests.js
+++ b/src/scenes/home/informationForm/formComponents/interests.js
@@ -8,6 +8,12 @@ import styles from './formComponents.css';
 
 class Interests extends Component {
 
+  componentDidMount() {
+    if (this.props.onLoad) {
+      this.props.onLoad();
+    }
+  }
+
   render() {
     const languages = LANGUAGES
       .map(language =>
@@ -59,12 +65,14 @@ class Interests extends Component {
 
 Interests.propTypes = {
   percent: PropTypes.string,
-  update: PropTypes.func
+  update: PropTypes.func,
+  onLoad: PropTypes.func
 };
 
 Interests.defaultProps = {
   percent: '0',
   update: null,
+  onLoad: null
 };
 
 export default Interests;

--- a/src/scenes/home/informationForm/formComponents/interests.js
+++ b/src/scenes/home/informationForm/formComponents/interests.js
@@ -15,7 +15,7 @@ class Interests extends Component {
           <FormCheckBox
             name={'languages'}
             value={language}
-            onChange={e => this.props.update(e.target.value)}
+            onChange={e => this.props.update(e)}
             key={language}
           />
       )
@@ -26,7 +26,7 @@ class Interests extends Component {
           <FormCheckBox
             name={'disciplines'}
             value={discipline}
-            onChange={e => this.props.update(e.target.value)}
+            onChange={e => this.props.update(e)}
             key={discipline}
           />
       )

--- a/src/scenes/home/informationForm/informationForm.js
+++ b/src/scenes/home/informationForm/informationForm.js
@@ -16,6 +16,7 @@ class SignupInformation extends Component {
     super(props);
     this.onIdentifierStatusChange = this.onIdentifierStatusChange.bind(this);
     this.onCheckBoxChange = this.onCheckBoxChange.bind(this);
+    this.previousPage = this.previousPage.bind(this);
     this.state = {
       error: false,
       isValid: true,

--- a/src/scenes/home/informationForm/informationForm.js
+++ b/src/scenes/home/informationForm/informationForm.js
@@ -17,6 +17,7 @@ class SignupInformation extends Component {
     this.onIdentifierStatusChange = this.onIdentifierStatusChange.bind(this);
     this.onCheckBoxChange = this.onCheckBoxChange.bind(this);
     this.previousPage = this.previousPage.bind(this);
+    this.onCheckboxLoad = this.onCheckboxLoad.bind(this);
     this.state = {
       error: false,
       isValid: true,
@@ -25,6 +26,15 @@ class SignupInformation extends Component {
       interests: new Set(),
       step: 0
     };
+  }
+
+  onCheckboxLoad = () => {
+    // Clear the interests once we get to the interests page
+    if (this.state.interests.size) {
+      const interests = new Set(this.state.interests);
+      interests.clear();
+      this.setState({ interests });
+    }
   }
 
   // On-Change handler dynamically creates state named after the
@@ -55,17 +65,7 @@ class SignupInformation extends Component {
       return;
     }
 
-    // Clear the interests if we go back from the interests page
-    const interests = new Set(this.state.interests);
-    if (this.state.identifier === 'false') {
-      if (this.state.step === 4) {
-        interests.clear();
-      }
-    } else if (this.state.step === 2) {
-      interests.clear();
-    }
-
-    this.setState({ step: this.state.step -= 1, interests });
+    this.setState({ step: this.state.step -= 1 });
   }
 
   // Patches whatever values that have been captured so far to the DB
@@ -125,6 +125,7 @@ class SignupInformation extends Component {
           <Interests
             update={this.onCheckBoxChange}
             percent={'66'}
+            onLoad={this.onCheckboxLoad}
           />
         );
       // Civillian COMPLETE

--- a/src/scenes/home/informationForm/informationForm.js
+++ b/src/scenes/home/informationForm/informationForm.js
@@ -54,7 +54,17 @@ class SignupInformation extends Component {
     if (this.state.step < 1) {
       return;
     }
-    this.setState({ step: this.state.step -= 1 });
+
+    const interests = new Set(this.state.interests);
+    if (this.state.identifier === 'false') {
+      if (this.state.step === 4) {
+        interests.clear();
+      }
+    } else if (this.state.step === 2) {
+      interests.clear();
+    }
+
+    this.setState({ step: this.state.step -= 1, interests });
   }
 
   // Patches whatever values that have been captured so far to the DB

--- a/src/scenes/home/informationForm/informationForm.js
+++ b/src/scenes/home/informationForm/informationForm.js
@@ -55,6 +55,7 @@ class SignupInformation extends Component {
       return;
     }
 
+    // Clear the interests if we go back from the interests page
     const interests = new Set(this.state.interests);
     if (this.state.identifier === 'false') {
       if (this.state.step === 4) {

--- a/src/scenes/home/informationForm/informationForm.js
+++ b/src/scenes/home/informationForm/informationForm.js
@@ -36,8 +36,16 @@ class SignupInformation extends Component {
   }
 
   // Adds values from checkboxes to a set, eliminating possible repeat values
-  onCheckBoxChange = (value) => {
-    this.setState({ interests: this.state.interests.add(value) });
+  onCheckBoxChange = (e) => {
+    const interests = new Set(this.state.interests);
+    const value = e.target.value;
+    if (e.target.checked) {
+      interests.add(value);
+    } else {
+      interests.delete(value);
+    }
+
+    this.setState({ interests });
   }
 
   // Reduces 'step' value by 1, going back one page in the form


### PR DESCRIPTION
# Description of changes
A few fixes during signup process:

- support deselecting interests

- clearing interests when going back from interests page

- bind `previousPage` function so it will have the `this` context

# Issue Resolved
Fixes #417 
