### PR TITLE
adding cards to gala page so that the tweets stand out more

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,8 @@
         <meta property="og:image" content="./images/logos/small-stacked-logo-blue.png" />
 
         <!--Twitter cards  -->
-        <meta name="twitter:card" content="summary" />
-        <meta name="twitter:site" content="@operationcode" />
-        <meta name="twitter:creator" content="@operationcode" />
+        <meta name="twitter:site" content="@operation_code" />
+        <meta name="twitter:creator" content="@operation_code" />
         <meta property="og:url" content="https://operationcode.org/gala" />
         <meta property="og:title" content="Join us at the gala!" />
         <meta property="og:description" content="The Operation Code Board of Directors, all-volunteer staff, and more than 3,211 members cordially invite you to the Deploy the Future Gala November 10, 2017 in the Governor Ballroom at Portland’s historic Sentinel Hotel." />

--- a/index.html
+++ b/index.html
@@ -9,6 +9,16 @@
         <meta name="keywords" content="operation code, veterans, software development, learn to code, keep coding, veteran coders, senate veterans, house veterans, gi bill, new gi bill, operationcode.org, #operationcode, military vets, vets">
         <meta name="author" content="Veteran Coders, for Veterans Coders">
         <meta property="og:image" content="./images/logos/small-stacked-logo-blue.png" />
+
+        <!--Twitter cards  -->
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:site" content="@operationcode" />
+        <meta name="twitter:creator" content="@operationcode" />
+        <meta property="og:url" content="https://operationcode.org/gala" />
+        <meta property="og:title" content="Join us at the gala!" />
+        <meta property="og:description" content="The Operation Code Board of Directors, all-volunteer staff, and more than 3,211 members cordially invite you to the Deploy the Future Gala November 10, 2017 in the Governor Ballroom at Portland’s historic Sentinel Hotel." />
+        <meta property="og:image" content="images/gala-banner.png" />
+
         <link rel="stylesheet" type="styles/css" href="styles/css/styles.css">
         <script src="https://cdn.ravenjs.com/3.16.0/raven.min.js" crossorigin="anonymous"></script>
         <script type="text/javascript">


### PR DESCRIPTION
# Description of changes
This PR adds "twitter cards" to the links for the gala so that when someone shares a link to the page on the site, it stands out more.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
There were no issues associated with this pull request.
Fixes #