### PR TITLE
#436 Fix side navigation menu in Firefox at smaller screen widths

### DIFF
--- a/src/scenes/home/header/sideNav/drawer/drawer.css
+++ b/src/scenes/home/header/sideNav/drawer/drawer.css
@@ -29,3 +29,9 @@
     display: block;
   }
 }
+
+@media screen and (orientation: landscape) {
+  .body {
+    width: 320px;
+  }
+}

--- a/src/scenes/home/header/sideNav/drawer/drawer.css
+++ b/src/scenes/home/header/sideNav/drawer/drawer.css
@@ -1,10 +1,10 @@
 .body {
   display: none;
-  position: absolute;
+  position: fixed;
   top: 0;
   bottom: 0;
   overflow: hidden;
-  width: 320px;
+  width: 100%;
   z-index: 2;
   transition: left .25s ease-in-out;
 }

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -57,20 +57,7 @@
   position: relative;
 }
 
-.navButton {
-  background: transparent;
-  border: none;
-  color: white;
-  text-align: left;
-  font-size: 2.5rem;
-  margin: 0.5rem 0;
-  padding: 0;
-}
-
 @media screen and (orientation: landscape) {
-  .content {
-    position: absolute;
-  }
   .list {
     font-size: 1.3em;
   }

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -6,8 +6,17 @@
 }
 
 .header {
-  display: flex;
-  flex-direction: column;
+  position: relative;
+  height: 80px;
+}
+
+.logo {
+  position: relative;
+  left: 5%;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 40px;
+  max-width: 75%;
 }
 
 .close {
@@ -16,27 +25,12 @@
   font-size: 40px;
   position: absolute;
   right: 5%;
-  top: 22px;
+  top: 20px;
   padding-right: 10px;
   line-height: 1;
 }
 
-.logoWrapper {
-  text-align: center;
-}
-
-.logo {
-  max-width: 75%;
-  max-height: 40px;
-  position: absolute;
-  top: 20px;
-  left: 5%;
-}
-
 .list {
-  display: flex;
-  flex-direction: column;
-  margin-top: 80px;
   padding: 30px 5%;
   border-top: 1px solid #fafafa;
   font-size: 2.5em;

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -25,9 +25,8 @@
   font-size: 40px;
   position: absolute;
   right: 5%;
-  top: 20px;
-  padding-right: 10px;
-  line-height: 1;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .list {

--- a/src/scenes/home/header/sideNav/sideNav.css
+++ b/src/scenes/home/header/sideNav/sideNav.css
@@ -3,7 +3,6 @@
   background-color:rgba(47,52,72,.95);
   height: 100%;
   width: 100%;
-  position: fixed;
 }
 
 .header {

--- a/src/scenes/home/header/sideNav/sideNav.js
+++ b/src/scenes/home/header/sideNav/sideNav.js
@@ -11,12 +11,10 @@ class SideNav extends Component {
       <Drawer isVisible={isVisible}>
         <div className={styles.content}>
           <div className={styles.header}>
-            <div>
-              <a className={styles.close} href="/" onClick={this.props.onClose}>&#10006;</a>
-            </div>
-            <a className={styles.logoWrapper} href="/">
+            <a href="/">
               <img className={styles.logo} src={logo} alt="Operation Code logo" />
             </a>
+            <a className={styles.close} href="/" onClick={this.props.onClose}>&#10006;</a>
           </div>
           <div className={styles.list}>
             {this.props.children}


### PR DESCRIPTION
# Description of changes
Adjusted CSS position rules for the sideNav component and the drawer component. The drawer is intended to be a reusable layout component (that can potentially be used for other things besides wrapping the sideNav's contents - anything else we want to slide out from the left for some reason.) When the drawer is visible, it needs full-screen height & width, so it gets the `position: fixed`.  The sideNav doesn't need that style.  

Seems like the `position: fixed` applied directly to the sideNav `.content` may have been interfering with the CSS transition in Firefox somehow. 

I tested this on current versions of Chrome, Firefox, Edge (Windows) and Chrome for Android - the  UI behaved as intended (no lock up or misrendering as was occurring on Firefox earlier) ... Recommend that someone who has an iPhone or Mac test it on those devices for regression testing @kylemh @Cooperbuilt 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #436
