### PR TITLE
Point 'Request Help' link in nav to working Airtable form #314

### DIFF
--- a/src/scenes/home/header/header.js
+++ b/src/scenes/home/header/header.js
@@ -28,7 +28,7 @@ class Header extends Component {
         <NavItem to="/about" text="About" onClick={onClick} />
         <NavItem to="/code_schools" text="Code Schools" onClick={onClick} />
         <NavItem to="https://donorbox.org/operationcode" text="Donate" onClick={onClick} isExternal />
-        {signedIn && <NavItem to="/mentor-request" text="Request Help" onClick={onClick} />}
+        {signedIn && <NavItem to="https://op.co.de/mentor-request" text="Request Help" onClick={onClick} isExternal />}
         {signedIn && <NavItem to="/mentors" text="Mentors" onClick={onClick} />}
         {mentor && <NavItem to="/requests" text="Requests" onClick={onClick} />}
         {signedIn && <NavItem to="/squads" text="Squads" onClick={onClick} />}


### PR DESCRIPTION
# Description of changes
Points the 'Request Help' link in the operationcode.org nav (desktop & mobile nav items) to the current, working Airtable form that we are using to track Mentor Requests on Airtable.  This is also the form that correctly notifies the #mentors-internal Slack channel when a request is added.

# Issue Resolved
This is a temporary stopgap fix for #341 - the issue should stay open.
