### PR TITLE
Indicate empty fields on submit. Fix for #423

### DIFF
--- a/src/scenes/home/signup/signup.js
+++ b/src/scenes/home/signup/signup.js
@@ -18,7 +18,7 @@ class SignUp extends Component {
     super(props);
     this.state = {
       email: '',
-      emailValid: true,
+      emailValid: false,
       error: false,
       isValid: true,
       isLoading: false,
@@ -97,6 +97,7 @@ class SignUp extends Component {
       });
     } else {
       this.setState({ error: 'Missing required field(s)', isLoading: false });
+      this.emailRef.inputRef.revalidate();
     }
   }
 
@@ -116,7 +117,11 @@ class SignUp extends Component {
             Once you complete the form below you&#8217;ll be invited
             to join our Slack team.  Make sure you stop in and say hi!
           </span>
-          <FormEmail id="email" placeholder="Email" onChange={this.onEmailChange} />
+          <FormEmail
+            id="email" placeholder="Email"
+            onChange={this.onEmailChange}
+            ref={(child) => { this.emailRef = child; }}
+          />
           <FormInput id="firstName" placeholder="First Name" onChange={this.onFirstNameChange} />
           <FormInput id="lastName" placeholder="Last Name" onChange={this.onLastNameChange} />
           <FormZipCode id="zip" placeholder="Zip Code" onChange={this.onZipChange} />

--- a/src/scenes/home/signup/signup.js
+++ b/src/scenes/home/signup/signup.js
@@ -25,10 +25,10 @@ class SignUp extends Component {
       mentor: false,
       password: '',
       passwordConfirm: '',
-      passwordValid: true,
+      passwordValid: false,
       success: false,
       zip: '',
-      zipValid: true
+      zipValid: false
     };
   }
 
@@ -61,7 +61,7 @@ class SignUp extends Component {
   }
 
   validatePasswordConfirm = value =>
-    value === '' || value === this.state.password;
+    value === this.state.password;
 
   handleOnClick = (e) => {
     e.preventDefault();
@@ -98,6 +98,11 @@ class SignUp extends Component {
     } else {
       this.setState({ error: 'Missing required field(s)', isLoading: false });
       this.emailRef.inputRef.revalidate();
+      this.firstNameRef.revalidate();
+      this.lastNameRef.revalidate();
+      this.zipRef.inputRef.revalidate();
+      this.passwordRef.inputRef.revalidate();
+      this.passwordConfirmRef.inputRef.revalidate();
     }
   }
 
@@ -122,18 +127,39 @@ class SignUp extends Component {
             onChange={this.onEmailChange}
             ref={(child) => { this.emailRef = child; }}
           />
-          <FormInput id="firstName" placeholder="First Name" onChange={this.onFirstNameChange} />
-          <FormInput id="lastName" placeholder="Last Name" onChange={this.onLastNameChange} />
-          <FormZipCode id="zip" placeholder="Zip Code" onChange={this.onZipChange} />
-          <FormPassword
-            id="password" placeholder="Password"
-            onChange={this.onPasswordChange} validationRegex={/^(?=.*[A-Z]).{6,}$/}
-            validationErrorMessage="Must be 6 characters long and include a capitalized letter"
+          <FormInput
+            id="firstName"
+            placeholder="First Name (Required)"
+            onChange={this.onFirstNameChange}
+            ref={(child) => { this.firstNameRef = child; }}
+          />
+          <FormInput
+            id="lastName"
+            placeholder="Last Name (Required)"
+            onChange={this.onLastNameChange}
+            ref={(child) => { this.lastNameRef = child; }}
+          />
+          <FormZipCode
+            id="zip"
+            placeholder="Zip Code (Required)"
+            onChange={this.onZipChange}
+            ref={(child) => { this.zipRef = child; }}
           />
           <FormPassword
-            id="passwordConfirm" placeholder="Confirm Password"
-            onChange={this.onConfirmPasswordChange} validateFunc={this.validatePasswordConfirm}
+            id="password"
+            placeholder="Password (Required)"
+            onChange={this.onPasswordChange}
+            validationRegex={/^(?=.*[A-Z]).{6,}$/}
+            validationErrorMessage="Must be 6 characters long and include a capitalized letter"
+            ref={(child) => { this.passwordRef = child; }}
+          />
+          <FormPassword
+            id="passwordConfirm"
+            placeholder="Confirm Password (Required)"
+            onChange={this.onConfirmPasswordChange}
+            validateFunc={this.validatePasswordConfirm}
             validationErrorMessage="Passwords must match"
+            ref={(child) => { this.passwordConfirmRef = child; }}
           />
           {this.state.error ? <ul className={styles.errorList}>There was an error joining Operation Code:
             <li className={styles.errorMessage}>{this.state.error}</li>

--- a/src/scenes/home/signup/signup.js
+++ b/src/scenes/home/signup/signup.js
@@ -118,7 +118,7 @@ class SignUp extends Component {
             to join our Slack team.  Make sure you stop in and say hi!
           </span>
           <FormEmail
-            id="email" placeholder="Email"
+            id="email" placeholder="Email (Required)"
             onChange={this.onEmailChange}
             ref={(child) => { this.emailRef = child; }}
           />

--- a/src/shared/components/form/formEmail/formEmail.js
+++ b/src/shared/components/form/formEmail/formEmail.js
@@ -9,6 +9,7 @@ class FormEmail extends Component {
         {...this.props}
         validationRegex={/\S+@\S+\.\S+/}
         validationErrorMessage="Must be a valid email"
+        ref={(child) => { this.inputRef = child; }}
       />
     );
   }

--- a/src/shared/components/form/formInput/formInput.js
+++ b/src/shared/components/form/formInput/formInput.js
@@ -27,8 +27,10 @@ class FormInput extends Component {
       return this.props.validateFunc(text);
     } else if (text.length > 0 && this.props.validationRegex) {
       return this.props.validationRegex.test(text);
+    } else if (text.length > 0) {
+      return true;
     }
-    return true;
+    return false;
   }
 
   revalidate() {
@@ -36,9 +38,9 @@ class FormInput extends Component {
     this.setState({ isValid: valid });
   }
 
-  componentWillReceiveProps(nextProps){
-    this.revalidate();
-  }
+  // componentWillReceiveProps(nextProps){
+  //   this.revalidate();
+  // }
 
   render() {
     return (

--- a/src/shared/components/form/formInput/formInput.js
+++ b/src/shared/components/form/formInput/formInput.js
@@ -38,10 +38,6 @@ class FormInput extends Component {
     this.setState({ isValid: valid });
   }
 
-  // componentWillReceiveProps(nextProps){
-  //   this.revalidate();
-  // }
-
   render() {
     return (
       <div className={styles.formInput}>

--- a/src/shared/components/form/formPassword/formPassword.js
+++ b/src/shared/components/form/formPassword/formPassword.js
@@ -8,6 +8,7 @@ class FormPassword extends Component {
       <FormInput
         {...this.props}
         inputType="password"
+        ref={(child) => { this.inputRef = child; }}
       />
     );
   }

--- a/src/shared/components/form/formZipCode/formZipCode.js
+++ b/src/shared/components/form/formZipCode/formZipCode.js
@@ -9,6 +9,7 @@ class FormZipCode extends Component {
         {...this.props}
         validationRegex={/(^\d{5}$)|(^\d{5}-\d{4}$)/}
         validationErrorMessage="Must be a valid US zip code"
+        ref={(child) => { this.inputRef = child; }}
       />
     );
   }


### PR DESCRIPTION
# Description of changes
Added visual feedback for empty required fields on submit. ~~Works just for the email field for now~~. Updated to work for all fields, see below.

The validation of email field occurs in the ```FormInput``` component with props passed by ```SignUp``` and ```FormEmail```. As I had to trigger a revalidation on form submit I took this approach in which I am calling ```revalidate()``` directly from ```SignUp``` through ref. Is this a right way to do it?

![current-working-gif](https://i.imgur.com/NF0mYyE.gif)

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #423 
