### PR TITLE
isseu 476 updated link for operation coder camps to the appropriate url 

### DIFF
--- a/src/scenes/home/codeSchools/partnerSchools/partnerSchools.js
+++ b/src/scenes/home/codeSchools/partnerSchools/partnerSchools.js
@@ -44,7 +44,7 @@ class PartnerSchools extends Component {
           <SchoolCard
             alt="Coder Camps Logo"
             schoolName="Coder Camps"
-            link="https://www.codeplatoon.org/"
+            link="http://www.operationcodercamps.com/"
             schoolAddress="Online, Pheonix, Seattle"
             logo="./images/codeSchoolLogos/coder_camps.jpg"
             GI="No"


### PR DESCRIPTION
This is my first pull request, ever so please be gentle :) I believe I've done everything correctly, but please let me know if things need changed.

# Description of changes
<!-- What does this PR change and why -->
the card for operation coder camps incorrectly linked too coode platoon. Updated the URL too http://www.operationcodercamps.com/ in the partnerschools.js file. I believe this is the only thing that needs updated for this issue.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #476
