### PR TITLE
Issue#472

### DIFF
--- a/src/scenes/home/informationForm/formComponents/interests.js
+++ b/src/scenes/home/informationForm/formComponents/interests.js
@@ -23,6 +23,8 @@ class Interests extends Component {
             value={language}
             onChange={e => this.props.update(e)}
             key={language}
+            checkBox={{ display: 'block', margin: '20px' }}
+            label={{ textTransform: 'uppercase', fontWeight: 'bold', marginLeft: '15px' }}
           />
       )
     );
@@ -34,6 +36,8 @@ class Interests extends Component {
             value={discipline}
             onChange={e => this.props.update(e)}
             key={discipline}
+            checkBox={{ display: 'block', margin: '20px' }}
+            label={{ textTransform: 'uppercase', fontWeight: 'bold', marginLeft: '15px' }}
           />
       )
     );

--- a/src/shared/components/form/formCheckBox/formCheckBox.css
+++ b/src/shared/components/form/formCheckBox/formCheckBox.css
@@ -1,14 +1,3 @@
-.checkBox {
-  display: block;
-  margin: 20px;
-}
-
 input[type=checkbox] {
   transform: scale(1.5);
-}
-
-.label {
-    text-transform: uppercase;
-    font-weight: bold;
-    margin-left: 15px;
 }

--- a/src/shared/components/form/formCheckBox/formCheckBox.js
+++ b/src/shared/components/form/formCheckBox/formCheckBox.js
@@ -6,7 +6,7 @@ class FormCheckBox extends Component {
 
   render() {
     return (
-      <div className={styles.checkBox}>
+      <div style={this.props.checkbox}>
         <input
           type="checkbox"
           name={this.props.name}
@@ -15,7 +15,7 @@ class FormCheckBox extends Component {
           onChange={this.props.onChange}
           className={styles.input}
         />
-        <label className={styles.label} htmlFor={this.props.name}>
+        <label style={this.props.label} htmlFor={this.props.name}>
           {this.props.value}
         </label>
       </div>
@@ -26,12 +26,23 @@ class FormCheckBox extends Component {
 FormCheckBox.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  checkbox: PropTypes.shape({
+    display: PropTypes.string,
+    margin: PropTypes.string
+  }),
+  label: PropTypes.shape({
+    textTransform: PropTypes.string,
+    fontWeight: PropTypes.string,
+    margin: PropTypes.string
+  })
 };
 
 FormCheckBox.defaultProps = {
   checked: false,
-  onChange: null
+  onChange: null,
+  checkbox: null,
+  label: null
 };
 
 export default FormCheckBox;

--- a/src/shared/components/form/formCheckBox/formCheckBox.js
+++ b/src/shared/components/form/formCheckBox/formCheckBox.js
@@ -6,7 +6,7 @@ class FormCheckBox extends Component {
 
   render() {
     return (
-      <div style={this.props.checkbox}>
+      <div style={this.props.checkBox}>
         <input
           type="checkbox"
           name={this.props.name}
@@ -27,7 +27,7 @@ FormCheckBox.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func,
-  checkbox: PropTypes.shape({
+  checkBox: PropTypes.shape({
     display: PropTypes.string,
     margin: PropTypes.string
   }),
@@ -41,7 +41,7 @@ FormCheckBox.propTypes = {
 FormCheckBox.defaultProps = {
   checked: false,
   onChange: null,
-  checkbox: null,
+  checkBox: null,
   label: null
 };
 


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
the styling for the formCheckBox component has been abstracted
a style object is now passed via prop

before: `className={styles.checkBox}`
after: `style={this.props.checkBox}`, `<formCheckBox ... checkBox={{ margin: '20px' }} />`

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #472 
