### PR TITLE
Enforce selecting description on signup

### DIFF
--- a/src/scenes/home/informationForm/formComponents/identifier.js
+++ b/src/scenes/home/informationForm/formComponents/identifier.js
@@ -6,6 +6,12 @@ import { IDENTIFIERS } from 'shared/constants/status';
 import styles from './formComponents.css';
 
 class Identifier extends Component {
+  // call the init method upon component creation
+  componentDidMount() {
+    if (this.props.init) {
+      this.props.init();
+    }
+  }
 
   render() {
     return (
@@ -16,18 +22,28 @@ class Identifier extends Component {
           prompt="Which describes you"
           onChange={e => this.props.update(e, e.target.value)}
           className={styles.signup}
+          validationFunc={e => this.props.validationFunc(e)}
         />
+        { !this.props.isValid && this.props.validationErrorMessage }
       </Form>
     );
   }
 }
 
 Identifier.propTypes = {
-  update: PropTypes.func
+  update: PropTypes.func,
+  validationFunc: PropTypes.func,
+  isValid: PropTypes.bool,
+  validationErrorMessage: PropTypes.string,
+  init: PropTypes.func
 };
 
 Identifier.defaultProps = {
-  update: null
+  update: null,
+  validationFunc: null,
+  isValid: true,
+  validationErrorMessage: null,
+  init: null
 };
 
 export default Identifier;

--- a/src/scenes/home/informationForm/informationForm.js
+++ b/src/scenes/home/informationForm/informationForm.js
@@ -21,6 +21,7 @@ class SignupInformation extends Component {
     this.state = {
       error: false,
       isValid: true,
+      isDescriptionValid: true,
       success: false,
       identifier: 'false',
       interests: new Set(),
@@ -58,6 +59,18 @@ class SignupInformation extends Component {
     this.setState({ interests });
   }
 
+  // make sure isDescriptionValid is false on initialization
+  onIdentifierInit = () => {
+    this.setState({ isDescriptionValid: false });
+  }
+
+  // check if an option was selected: volunteer / veteran
+  validateDescription = (value) => {
+    const isDescriptionValid = Boolean(value.length);
+    this.setState({ isDescriptionValid });
+    return isDescriptionValid;
+  }
+
   // Reduces 'step' value by 1, going back one page in the form
   // Unless you are at the first page
   previousPage = () => {
@@ -68,9 +81,24 @@ class SignupInformation extends Component {
     this.setState({ step: this.state.step -= 1 });
   }
 
+  isFormValid = () => {
+    let valid = true;
+    if (!this.state.isDescriptionValid) {
+      valid = false;
+    }
+
+    this.setState({ error: !valid });
+    return valid;
+  }
+
   // Patches whatever values that have been captured so far to the DB
   // Then adds 1 to step to progress to the next page.
   saveAndContinue = () => {
+    // check if the form is valid before submitting
+    if (!this.isFormValid()) {
+      return;
+    }
+
     patchBackend('users', {
       user: {
         education_level: this.state.schoolLevel,
@@ -166,7 +194,15 @@ class SignupInformation extends Component {
         );
       // STEP ONE
       default:
-        return <Identifier update={this.onIdentifierStatusChange} />;
+        return (
+          <Identifier
+            update={this.onIdentifierStatusChange}
+            validationFunc={e => this.validateDescription(e.target.value)}
+            validationErrorMessage="You have to select a value"
+            isValid={this.state.isDescriptionValid}
+            init={this.onIdentifierInit}
+          />
+        );
     }
   }
 

--- a/src/shared/components/form/formSelect/formSelect.js
+++ b/src/shared/components/form/formSelect/formSelect.js
@@ -2,6 +2,18 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 export default class FormSelect extends Component {
+  onChange(e) {
+    // make sure we have a valid value before propogating the on change call
+    let isValid = true;
+    if (this.props.validationFunc) {
+      isValid = this.props.validationFunc(e);
+    }
+
+    if (isValid && this.props.onChange) {
+      this.props.onChange(e);
+    }
+  }
+
   buildOptions = () => {
     const { prompt, options } = this.props;
     const opts = [];
@@ -15,9 +27,11 @@ export default class FormSelect extends Component {
 
   render() {
     return (
-      <select id={this.props.id} onChange={this.props.onChange}>
-        {this.buildOptions()}
-      </select>
+      <div>
+        <select id={this.props.id} onChange={e => this.onChange(e)}>
+          {this.buildOptions()}
+        </select>
+      </div>
     );
   }
 }
@@ -29,11 +43,13 @@ FormSelect.propTypes = {
     label: PropTypes.string.isRequired
   })).isRequired,
   onChange: PropTypes.func,
-  id: PropTypes.string
+  id: PropTypes.string,
+  validationFunc: PropTypes.func
 };
 
 FormSelect.defaultProps = {
   onChange: () => {},
   prompt: null,
-  id: null
+  id: null,
+  validationFunc: null
 };


### PR DESCRIPTION
# Description of changes
support validation of signup-info form and form select.
this will enforce new users selecting their title (veteran or relative / volunteer)

![screen shot 2017-09-09 at 5 01 19 pm](https://user-images.githubusercontent.com/3673138/30240839-99bc48e4-9580-11e7-8c10-5cb767265a73.png)
![screen shot 2017-09-09 at 5 01 46 pm](https://user-images.githubusercontent.com/3673138/30240838-99b7899e-9580-11e7-975c-0e3b3741aba2.png)



# Issue Resolved
Fixes #491 
