### PR TITLE
Add more references to Discourse in our copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,11 @@ yarn start
 If you're an experienced developer, please navigate to our [Quick Start Guide](https://github.com/OperationCode/operationcode_frontend/blob/master/CONTRIBUTING.md#quick-start-guide).
 
 ## What is a frontend?
-When you visit our website you're intereacting with two systems, a frontend application and a backend application.
-The frontend application (where you are now) is responsible for displaying images, text and data on our web pages.
-Frontend applications are usually written using a combination of HTML, CSS, and Javascript and utilize 1 or more
-frameworks such as Angular, backbone, vue, and react. https://operationcode.org uses react.
+When you visit our website you're interacting with two systems, a frontend application and a backend application. The frontend application (where you are now) is responsible for displaying images, text and data on our web pages.
+Frontend applications are usually written using a combination of HTML, CSS, and Javascript and utilize one or more frameworks such as Angular, Backbone, Vue, and React. https://operationcode.org uses React.
 
 ## What is a backend?
-The backend is responsible for providing data to the front end to display, and processing data entered into the
-frontend, and running various jobs like inviting new users to slack, or signing them up for our newsletter. The
-https://operationcode.org backend is written in rails and can be viewed at
-https://github.com/OperationCode/operationcode_backend.
+The backend is responsible for providing data to the front end to display, and processing data entered into the frontend, and running various jobs like inviting new users to Slack, or signing them up for our newsletter. The https://operationcode.org backend is written in Rails and can be viewed at https://github.com/OperationCode/operationcode_backend.
 
 ## Contribute
 Want to contribute to this repo? Check out our comprehensive

--- a/src/scenes/home/codeSchools/codeSchools.js
+++ b/src/scenes/home/codeSchools/codeSchools.js
@@ -40,7 +40,7 @@ class CodeSchools extends Component {
             <br />
             <br />
             We encourage you to check out the schools below, do your research, and ask fellow
-            software developers in <a href="https://operation-code.slack.com/" target="_blank" rel="noopener noreferrer">Slack</a>.
+            software developers in <a href="https://operation-code.slack.com/" target="_blank" rel="noopener noreferrer">Slack</a> or our <a href="https://community.operationcode.org/" target="_blank" rel="noopener noreferrer">forums</a>.
           </p>
 
           <div className={styles.filterButtonDiv}>

--- a/src/scenes/home/codeSchools/codeSchools.js
+++ b/src/scenes/home/codeSchools/codeSchools.js
@@ -40,7 +40,7 @@ class CodeSchools extends Component {
             <br />
             <br />
             We encourage you to check out the schools below, do your research, and ask fellow
-            software developers in <a href="https://operation-code.slack.com/" target="_blank" rel="noopener noreferrer">Slack</a> or our <a href="https://community.operationcode.org/" target="_blank" rel="noopener noreferrer">forums</a>.
+            software developers in Slack or our <a href="https://community.operationcode.org/" target="_blank" rel="noopener noreferrer">forums</a>.
           </p>
 
           <div className={styles.filterButtonDiv}>

--- a/src/scenes/home/contact/contact.js
+++ b/src/scenes/home/contact/contact.js
@@ -13,7 +13,7 @@ class Contact extends Component {
             We are a decentralized community of hard-working volunteers, and we love hearing feedback, comments, and suggestions!
             <br />
             <br />
-            The best way to reach our staff and our members is by <Link to="join">joining Operation Code</Link> to receive an invite to our team, including our <a href="https://operation-code.slack.com/" target="_blank" rel="noopener noreferrer">Slack chat</a> and <a href="https://community.operationcode.org/" target="_blank" rel="noopener noreferrer">forums</a>. You can also reach us via email, physical mail, or via <a href="//twitter.com/operation_code" target="_blank" rel="noopener noreferrer">Twitter.</a>
+            The best way to reach our staff and our members is by <Link to="join">joining Operation Code</Link> to receive an invite to our team, including our Slack chat and <a href="https://community.operationcode.org/" target="_blank" rel="noopener noreferrer">forums</a>. You can also reach us via email, physical mail, or via <a href="//twitter.com/operation_code" target="_blank" rel="noopener noreferrer">Twitter.</a>
           </p>
         </Section>
 

--- a/src/scenes/home/contact/contact.js
+++ b/src/scenes/home/contact/contact.js
@@ -13,7 +13,7 @@ class Contact extends Component {
             We are a decentralized community of hard-working volunteers, and we love hearing feedback, comments, and suggestions!
             <br />
             <br />
-            The best way to reach our staff and our members is by <Link to="join">joining Operation Code</Link> to receive an invite to our Slack team. You can also reach us via email, physical mail, or via <a href="//twitter.com/operation_code" target="_blank" rel="noopener noreferrer">Twitter.</a>
+            The best way to reach our staff and our members is by <Link to="join">joining Operation Code</Link> to receive an invite to our team, including our <a href="https://operation-code.slack.com/" target="_blank" rel="noopener noreferrer">Slack chat</a> and <a href="https://community.operationcode.org/" target="_blank" rel="noopener noreferrer">forums</a>. You can also reach us via email, physical mail, or via <a href="//twitter.com/operation_code" target="_blank" rel="noopener noreferrer">Twitter.</a>
           </p>
         </Section>
 

--- a/src/scenes/home/faq/questions.json
+++ b/src/scenes/home/faq/questions.json
@@ -14,7 +14,7 @@
     },
     {
       "question": "Where is Operation Code based? Do you have a location near me?",
-      "answer": "Operation Code, much like software, is built from anywhere with an internet connection, and is not based in one location. While we're headquartered in Portland, the entire organization is decentralized, including the board of directors and the core team. This allows us to more effectively serve the entire military community, whether they're veterans or military spouses, whether they're OCONUS or in-country. We have chapters all over the nation. Use Slack and join the closest town to you!"
+      "answer": "Operation Code, much like software, is built from anywhere with an internet connection, and is not based in one location. While we're headquartered in Portland, the entire organization is decentralized, including the board of directors and the core team. This allows us to more effectively serve the entire military community, whether they're veterans or military spouses, whether they're OCONUS or in-country. We have chapters all over the nation. Use Slack or our forums, and join the closest town to you!"
     },
     {
       "question": "Who does Operation Code serve?",
@@ -26,7 +26,7 @@
     },
     {
       "question": "What is available to start learning to code today?",
-      "answer": "Our friends at the New York City-based, The Flatiron School created <a href=\"https://learn.co/\">Learn.co</a>, an online platform to get introduced to web development and the popular web framework, Ruby on Rails. Request an invite <a href=\"https://learn.co/join/operation-code\">here</a> and then join the #learn-dot-co channel in our Slack if you get stuck. Another resource is <a href=\"https://www.learnhowtoprogram.com/courses\">learnhowtoprogram.com</a>, a resource maintained by Epicodus."
+      "answer": "Our friends at the New York City-based, The Flatiron School created <a href=\"https://learn.co/\">Learn.co</a>, an online platform to get introduced to web development and the popular web framework, Ruby on Rails. Request an invite <a href=\"https://learn.co/join/operation-code\">here</a> and then join the #learn-dot-co channel in our Slack, or post to our forums if you get stuck. Another resource is <a href=\"https://www.learnhowtoprogram.com/courses\">learnhowtoprogram.com</a>, a resource maintained by Epicodus."
     },
     {
       "question": "What are the hours of operation for Operation Code?",

--- a/src/scenes/home/faq/questions.json
+++ b/src/scenes/home/faq/questions.json
@@ -14,7 +14,7 @@
     },
     {
       "question": "Where is Operation Code based? Do you have a location near me?",
-      "answer": "Operation Code, much like software, is built from anywhere with an internet connection, and is not based in one location. While we're headquartered in Portland, the entire organization is decentralized, including the board of directors and the core team. This allows us to more effectively serve the entire military community, whether they're veterans or military spouses, whether they're OCONUS or in-country. We have chapters all over the nation. Use Slack or our forums, and join the closest town to you!"
+      "answer": "Operation Code, much like software, is built from anywhere with an internet connection, and is not based in one location. While we're headquartered in Portland, the entire organization is decentralized, including the board of directors and the core team. This allows us to more effectively serve the entire military community, whether they're veterans or military spouses, whether they're OCONUS or in-country. We have chapters all over the nation. Use Slack or our <a href=\"https://community.operationcode.org/\" target=\"_blank\" rel=\"noopener noreferrer\">forums</a>, and join the closest town to you!"
     },
     {
       "question": "Who does Operation Code serve?",
@@ -26,11 +26,11 @@
     },
     {
       "question": "What is available to start learning to code today?",
-      "answer": "Our friends at the New York City-based, The Flatiron School created <a href=\"https://learn.co/\">Learn.co</a>, an online platform to get introduced to web development and the popular web framework, Ruby on Rails. Request an invite <a href=\"https://learn.co/join/operation-code\">here</a> and then join the #learn-dot-co channel in our Slack, or post to our forums if you get stuck. Another resource is <a href=\"https://www.learnhowtoprogram.com/courses\">learnhowtoprogram.com</a>, a resource maintained by Epicodus."
+      "answer": "Our friends at the New York City-based, The Flatiron School created <a href=\"https://learn.co/\">Learn.co</a>, an online platform to get introduced to web development and the popular web framework, Ruby on Rails. Request an invite <a href=\"https://learn.co/join/operation-code\">here</a> and then join the #learn-dot-co channel in our Slack, or post to our <a href=\"https://community.operationcode.org/\" target=\"_blank\" rel=\"noopener noreferrer\">forums</a> if you get stuck. Another resource is <a href=\"https://www.learnhowtoprogram.com/courses\">learnhowtoprogram.com</a>, a resource maintained by Epicodus."
     },
     {
       "question": "What are the hours of operation for Operation Code?",
-      "answer": "Operation Code is different in that we don't have regular business office hours. The team can usually be found in our <a href='http://operation-code.slack.com'>Slack channel</a>, or <a href='https://github.com/OperationCode/operationcode'>GitHub</a> fixing bugs and implementing new features."
+      "answer": "Operation Code is different in that we don't have regular business office hours. The team can usually be found in our <a href='http://operation-code.slack.com'>Slack channel</a>, or on <a href='https://github.com/OperationCode/operationcode'>GitHub</a> fixing bugs and implementing new features. We can also be reached on the <a href=\"https://community.operationcode.org/\" target=\"_blank\" rel=\"noopener noreferrer\">forums</a>."
     },
     {
       "question": "How can I help, if I can't afford to donate to Operation Code?",

--- a/src/scenes/home/landing/membership/membership.js
+++ b/src/scenes/home/landing/membership/membership.js
@@ -14,7 +14,7 @@ class Membership extends Component {
         <div className={styles.intro}>
           <p>
             Joining Operation Code is easy - and free! Once you&#39;re signed up, you can join us on
-            Slack and start enjoying the benefits of your membership:
+            <a href="https://operation-code.slack.com/" target="_blank" rel="noopener noreferrer">Slack</a> or our <a href="https://community.operationcode.org/" target="_blank" rel="noopener noreferrer">forums</a> and start enjoying the benefits of your membership:
           </p>
         </div>
         <br />

--- a/src/scenes/home/press/press.js
+++ b/src/scenes/home/press/press.js
@@ -21,7 +21,7 @@ class Press extends Component {
             <div className={styles.column}>
               <h4>Code Schools</h4>
               <p>
-                Firstly, if your code school&apos;s information is not listed on our directory, please contact us at <a href="mailto:staff@operationcode.org">staff@operationcode.org</a>. If your school has recently partnered with our organization and is seeking information to write about it a blog post, we recommend joining our Slack team to receive personal anecdotes from our members, many of whom have attended various coding schools - perhaps yours!
+                Firstly, if your code school&apos;s information is not listed on our directory, please contact us at <a href="mailto:staff@operationcode.org">staff@operationcode.org</a>. If your school has recently partnered with our organization and is seeking information to write about it a blog post, we recommend joining our <a href="https://operation-code.slack.com/" target="_blank" rel="noopener noreferrer">Slack</a> team to receive personal anecdotes from our members, many of whom have attended various coding schools - perhaps yours!
               </p>
             </div>
 

--- a/src/scenes/home/press/press.js
+++ b/src/scenes/home/press/press.js
@@ -21,7 +21,7 @@ class Press extends Component {
             <div className={styles.column}>
               <h4>Code Schools</h4>
               <p>
-                Firstly, if your code school&apos;s information is not listed on our directory, please contact us at <a href="mailto:staff@operationcode.org">staff@operationcode.org</a>. If your school has recently partnered with our organization and is seeking information to write about it a blog post, we recommend joining our <a href="https://operation-code.slack.com/" target="_blank" rel="noopener noreferrer">Slack</a> team to receive personal anecdotes from our members, many of whom have attended various coding schools - perhaps yours!
+                Firstly, if your code school&apos;s information is not listed on our directory, please contact us at <a href="mailto:staff@operationcode.org">staff@operationcode.org</a>. If your school has recently partnered with our organization and is seeking information to write about it a blog post, we recommend joining our Slack team to receive personal recommendations from our members, many of whom have attended various coding schools - perhaps yours!
               </p>
             </div>
 

--- a/src/scenes/home/signup/signup.js
+++ b/src/scenes/home/signup/signup.js
@@ -120,7 +120,7 @@ class SignUp extends Component {
             Are you ready to deploy your future?  Join Operation Code
             today and launch your career in software development.
             Once you complete the form below you&#8217;ll be invited
-            to join our Slack team.  Make sure you stop in and say hi!
+            to join our team on Slack and the <a href="https://community.operationcode.org/" target="_blank" rel="noopener noreferrer">forums</a>.  Make sure you stop in and say hi!
           </span>
           <FormEmail
             id="email" placeholder="Email (Required)"


### PR DESCRIPTION
# Description of changes
Makes it more apparent that we have https://community.operationcode.org/, and not just a Slack team.