### PR TITLE
[WIP] Disable no-did-mount-set-state rule globally

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "comma-dangle": [1, "only-multiline"],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/prefer-stateless-function": 0,
+    "react/no-did-mount-set-state": 0,
     "import/extensions": 0,
     "import/no-extraneous-dependencies": 0,
     "linebreak-style": 0,


### PR DESCRIPTION
# Description of changes
Disables the JS Linter for `no-did-mount-set-state` globally.

# Issue Resolved
As per @kylemh's direction, this resolves some current disagreements with AirBnB. I've only commented this out so that we can re-enable it when there are some overrides in place for linting.
