### PR TITLE
Fix "What We Do" titles CSS

### DIFF
--- a/src/scenes/home/scholarship/preview/preview.css
+++ b/src/scenes/home/scholarship/preview/preview.css
@@ -1,9 +1,3 @@
-a {
-  text-decoration: none;
-  font-family: "Noto Serif", sans-serif;
-  color: rgb(71, 86, 107);
-}
-
 .preview {
   position: relative;
   background: rgb(255, 255, 255);
@@ -12,6 +6,10 @@ a {
   padding: 1em 1em;
   border-radius: .28571429rem;
   border: 1px solid rgba(34,36,38,.15);
+  text-decoration: none;
+  font-family: "Noto Serif", sans-serif;
+  color: rgb(71, 86, 107);
+  display: block;
 }
 
 .preview:hover {
@@ -19,16 +17,15 @@ a {
   box-shadow: 0 14px 28px rgba(0,0,0,0.25);
 }
 
-.preview:hover > h6::after {
+.preview:hover h6::after {
   background-color: rgb(65, 164, 192);
 }
 
-h6 {
+.preview h6 {
   display: flex;
-  letter-spacing: .05em;
 }
 
-h6::after {
+.preview h6::after {
   flex-grow: 1;
   height: 3px;
   content: '\a0';

--- a/src/scenes/home/scholarship/preview/preview.js
+++ b/src/scenes/home/scholarship/preview/preview.js
@@ -11,8 +11,8 @@ class Preview extends Component {
   render() {
     const scholarship = this.props.scholarship;
     return (
-      <a href={`scholarships/${scholarship.id}/apply`}>
-        <div className={styles.preview} >
+      <a href={`scholarships/${scholarship.id}/apply`} className={styles.preview}>
+        <div>
           <h6>{scholarship.name}</h6>
           <span> {this.snip(scholarship.description)} </span>
         </div>

--- a/src/scenes/home/scholarship/scholarships.js
+++ b/src/scenes/home/scholarship/scholarships.js
@@ -28,7 +28,7 @@ class Scholarships extends Component {
       schlrshps = this.state.scholarships.map(scholarship => <Preview key={scholarship.id} scholarship={scholarship} />);
     }
     return (
-      <Section title={'Scholarhips'}>
+      <Section title={'Scholarships'}>
         <div className={styles.container}>
           {schlrshps}
         </div>

--- a/src/shared/components/imageCard/imageCard.css
+++ b/src/shared/components/imageCard/imageCard.css
@@ -25,7 +25,7 @@
   display: flex;
   flex-flow: column;
   justify-content: space-around;
-  align-items: center;
+  align-items: left;
 }
 
 .cardText > h6 {


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
This adjusts some CSS for the `<Preview>` component that was affecting the homepage "What We Do" section titles. 

* Also aligns these titles left, which is definitely is a personal preference (let me know if you think we should revert that).
* Fixes typo.
* Adds backup default link color (see first paragraph in "Membership" section)

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #511 
