### PR TITLE
Add space before Slack link on home page

### DIFF
--- a/src/scenes/home/landing/membership/membership.js
+++ b/src/scenes/home/landing/membership/membership.js
@@ -13,7 +13,7 @@ class Membership extends Component {
       <Section title="Membership" theme="white">
         <div className={styles.intro}>
           <p>
-            Joining Operation Code is easy - and free! Once you&#39;re signed up, you can join us on
+            Joining Operation Code is easy - and free! Once you&#39;re signed up, you can join us on&nbsp;
             <a href="https://operation-code.slack.com/" target="_blank" rel="noopener noreferrer">Slack</a> or our <a href="https://community.operationcode.org/" target="_blank" rel="noopener noreferrer">forums</a> and start enjoying the benefits of your membership:
           </p>
         </div>


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Adds a space before Slack link on home page.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
No issue created
