### PR TITLE
Force TimelineEvent.js Title to be TitleCase with Regex #531

### DIFF
--- a/src/scenes/home/history/timelineEvent/timelineEvent.css
+++ b/src/scenes/home/history/timelineEvent/timelineEvent.css
@@ -5,6 +5,10 @@
   border-radius: 5px;
 }
 
+.eventTitle {
+  text-transform: capitalize;
+}
+
 @media screen and (max-width: 680px) {
   .eventTitle {
     font-size: 1.5rem;

--- a/src/scenes/home/history/timelineEvent/timelineEvent.js
+++ b/src/scenes/home/history/timelineEvent/timelineEvent.js
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types';
 import styles from './timelineEvent.css';
 
 class TimelineEvent extends Component {
-  titleCase = title => title.toLowerCase().replace(/(^[a-z]| [a-z])/g, match => match.toUpperCase());
-
   render() {
     return (
       <div className={styles.eventContainer}>
         <h4 className={styles.eventTitle}>
-          {this.titleCase(this.props.title)}
+          {this.props.title}
         </h4>
+
         <div className={styles.eventContent}>
           <p>
             {this.props.content}

--- a/src/scenes/home/history/timelineEvent/timelineEvent.js
+++ b/src/scenes/home/history/timelineEvent/timelineEvent.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 import styles from './timelineEvent.css';
 
 class TimelineEvent extends Component {
+  titleCase = title => title.toLowerCase().replace(/(^[a-z]| [a-z])/g, match => match.toUpperCase());
+
   render() {
     return (
       <div className={styles.eventContainer}>
         <h4 className={styles.eventTitle}>
-          {this.props.title}
+          {this.titleCase(this.props.title)}
         </h4>
-
         <div className={styles.eventContent}>
           <p>
             {this.props.content}


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Added new method to TimelineEvent forcing the title to be title case. I thought about adding this to a helper file but noticed you don't have a general helper util file, but let me know if you'd prefer I implement this another way.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #531 
