### PR TITLE
Adds prerequisites for the quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ If you're here looking for a place to contribute pull requests as part of GitHub
 ## Quick Start
 
 ### TLDR
+
+Prerequisites:
+
+- [Yarn](https://yarnpkg.com/en/)
+- [Docker](https://www.docker.com/)
+
 ```
 yarn
 ```
@@ -18,7 +24,7 @@ yarn
 ```
 yarn run backend
 ```
-If it doesn't work the first time, run it again.
+If the command doesn't work the first time, run it again.
 
 In another shell tab:
 ```


### PR DESCRIPTION
# Description of changes

This PR adds two prerequisites to the "Quick Start" section of the README: Yarn and Docker. I recognize that technically Yarn is not a prereq, but Docker certainly is. `yarn run backend` will fail without it.

The other line came from my first instinct of where to add the Docker reference and then I kept it. Pronouns should always have a noun they reference. hashtag grammar nerd.