### PR TITLE
removes unused prop in Button component

### DIFF
--- a/src/shared/components/button/button.js
+++ b/src/shared/components/button/button.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 const Button = (props) => {
   const {
     handleClick,
-    link,
     ...otherProps
   } = props;
 
@@ -14,13 +13,11 @@ const Button = (props) => {
 };
 
 Button.propTypes = {
-  handleClick: PropTypes.func,
-  link: PropTypes.string
+  handleClick: PropTypes.func
 };
 
 Button.defaultProps = {
-  handleClick: null,
-  link: null
+  handleClick: null
 };
 
 export default Button;


### PR DESCRIPTION
# Description of changes

This PR removes the unused `link` prop on the button component. As it was, the `link` prop was not being passed to the returned `button` element. Thus, I removed it.
