### PR TITLE
Fix spacing for membership items on landing page.

### DIFF
--- a/src/scenes/home/landing/membership/membership.css
+++ b/src/scenes/home/landing/membership/membership.css
@@ -8,7 +8,6 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: space-around;
-  width: 90%;
   margin: 0;
   padding: 0;
 }

--- a/src/scenes/home/landing/membership/membership.css
+++ b/src/scenes/home/landing/membership/membership.css
@@ -8,13 +8,12 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: space-around;
-  width: 80%;
+  width: 90%;
   margin: 0;
   padding: 0;
 }
 
 .list li {
-  width: 205px;
   list-style: none;
   margin: 0;
   font-size: 16px;


### PR DESCRIPTION
Remove fixed width on membership list items, increase list width from 80% to 90% to prevent items from wrapping to the next row too early.

Issue said that the problem was with the IconCard component, but the CSS in the containing membership component was the issue.

Fixes #620 
