### PR TITLE
Only send sentry errors when the host equals operationcode.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,11 @@
 <body>
   <div id="app"></div>
   <script>
-    Raven.config('https://a566cf6623524f11990720bcff927f75@sentry.io/207359').install();
+    Raven.config('https://a566cf6623524f11990720bcff927f75@sentry.io/207359!', {
+      shouldSendCallback: function() {
+        return window.location.host === 'operationcode.org';
+      }
+    }).install();
   </script>
   <script src="scripts/src/app.js"></script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,11 @@
 <body>
   <div id="root"></div>
   <script>
-    Raven.config('https://23e9c0c37a3841b8a692c98b8978f515@sentry.io/147247').install();
+    Raven.config('https://23e9c0c37a3841b8a692c98b8978f515@sentry.io/147247', {
+      shouldSendCallback: function() {
+        return window.location.host === 'operationcode.org';
+      }
+    }).install();
   </script>
   <!--
       This HTML file is a template.


### PR DESCRIPTION
# Description of changes
Error logs are send to sentry on non production environments. To prevent this from happening I've used the [shouldSendCallback](https://docs.sentry.io/clients/javascript/config/) which only sends data when the host equals operationcode.org.

# Issue Resolved
Fixes #428
