### PR TITLE
Note in the readme that tooling is not for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Prerequisites:
 
 - [Yarn](https://yarnpkg.com/en/)
 - [Docker](https://www.docker.com/)
-- OsX or Linux with a globally installed and available `git` (at the moment, all the tooling assumes this as a platform)
+- MacOS or Linux with a globally installed and available `git`
+  - If you are using Windows, we do not yet have documentation to safely install in a Powershell (or other Windows shell) environment. 
 
 ```
 yarn

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Prerequisites:
 
 - [Yarn](https://yarnpkg.com/en/)
 - [Docker](https://www.docker.com/)
+- OsX or Linux with a globally installed and available `git` (at the moment, all the tooling assumes this as a platform)
 
 ```
 yarn


### PR DESCRIPTION

Ran into issues in #javascript where someone was trying to follow Quick Start instructions on Windows. Digging through its not set up for that at all. In fact, the way the docker is configured I doubt it will work on windows
