### PR TITLE
#643 coverted successStories component to stateless

### DIFF
--- a/src/scenes/home/landing/successStories/successStories.js
+++ b/src/scenes/home/landing/successStories/successStories.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Section from 'shared/components/section/section';
 import ImageListItem from 'shared/components/imageListItem/imageListItem';
 import image1 from 'images/Jon-Deng.jpeg';
@@ -7,31 +7,14 @@ import image3 from 'images/Sean-McBride.jpg';
 import content from './successStoriesContent.json';
 import styles from './successStories.css';
 
-
-class SuccessStories extends Component {
-  render() {
-    return (
-      <Section title="Success Stories" theme="white">
-        <div className={styles.successStoriesContent}>
-          <ImageListItem
-            image={image1}
-            title={content.items[0].title}
-            cardText={content.items[0].body}
-          />
-          <ImageListItem
-            image={image2}
-            title={content.items[1].title}
-            cardText={content.items[1].body}
-          />
-          <ImageListItem
-            image={image3}
-            title={content.items[2].title}
-            cardText={content.items[2].body}
-          />
-        </div>
-      </Section>
-    );
-  }
-}
+const SuccessStories = () => (
+  <Section title="Success Stories" theme="white">
+    <div className={styles.successStoriesContent}>
+      <ImageListItem image={image1} title={content.items[0].title} cardText={content.items[0].body} />
+      <ImageListItem image={image2} title={content.items[1].title} cardText={content.items[1].body} />
+      <ImageListItem image={image3} title={content.items[2].title} cardText={content.items[2].body} />
+    </div>
+  </Section>
+);
 
 export default SuccessStories;


### PR DESCRIPTION
# Description of changes
Success Stories Portraits were being "squished" upon initial rendered. Must have been a race condition. Went ahead and converted successStories to a stateless component per @kylemh recommendation. Seem to fix it for now on chrome but shows ghosting of "squished" image.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Works to sometimes avoid #643 
