### PR TITLE
ensure imageListItem images are round

### DIFF
--- a/src/shared/components/imageListItem/imageListItem.css
+++ b/src/shared/components/imageListItem/imageListItem.css
@@ -13,6 +13,7 @@
   border: 3px solid #41a4c0;
   width: 150px;
   height: 150px;
+  max-height: 150px;
 }
 
 .cardText {

--- a/src/shared/components/imageListItem/imageListItem.css
+++ b/src/shared/components/imageListItem/imageListItem.css
@@ -12,6 +12,7 @@
   border-radius: 50%;
   border: 3px solid #41a4c0;
   width: 150px;
+  max-width: 150px;
   height: 150px;
   max-height: 150px;
 }


### PR DESCRIPTION
# Description of changes
imageListItem images (used within the 'success stories' section) now limited in height so they don't become elongated

# Issue Resolved
Fixes #643