### PR TITLE
add various usage story examples for iconCard component

### DIFF
--- a/stories/components/iconCard/index.js
+++ b/stories/components/iconCard/index.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+
+import IconCard from 'shared/components/iconCard/iconCard';
+
+
+storiesOf('shared/components/iconCard', module)
+  .add('Default', () => (
+    <IconCard
+      title="Title"
+      fontAwesomeIcon="FaRoad"
+    />
+  ))
+  .add('With subText', () => (
+    <IconCard
+      title="Title"
+      subText="Sub-text showing additional information"
+      fontAwesomeIcon="FaGroup"
+    />
+  ))
+  .add('Linked', () => (
+    <IconCard
+      title="Title"
+      subText="http://www.slack.com"
+      url="http://www.slack.com"
+      fontAwesomeIcon="FaSlack"
+    />
+  ))
+  .add('Sized icon', () => (
+    <IconCard
+      title="Title"
+      fontAwesomeIcon="FaStar"
+      iconSize="200"
+    />
+  ))
+  .add('Icon above heading', () => (
+    <IconCard
+      title="Title"
+      fontAwesomeIcon="FaThumbsUp"
+      iconAboveHeading
+    />
+  ))
+  .add('Preformatted subtext (using HTML)', () => (
+    <IconCard
+      title="Title"
+      fontAwesomeIcon="FaHtml5"
+      subText="<strong>Test</strong><br/>
+      <em>Test</em><br/>
+      <strike>Test<strike>"
+      usingHtml
+    />
+  ));

--- a/stories/components/iconCard/index.js
+++ b/stories/components/iconCard/index.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-
 import IconCard from 'shared/components/iconCard/iconCard';
-
 
 storiesOf('shared/components/iconCard', module)
   .add('Default', () => (


### PR DESCRIPTION
demonstrates the following iconCard types:

- default (title and icon)
- with subtext
- linked
- sized icon
- icon above heading
- preformatted subtext (using HTML)
