### PR TITLE
Checking image file sizes before commiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "0.11.1",
     "fs-extra": "3.0.1",
+    "globby": "^6.1.0",
     "html-webpack-plugin": "2.28.0",
     "http-proxy-middleware": "0.17.3",
     "jest": "20.0.3",
@@ -88,7 +89,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "backend": "./bin/run_backend.sh",
-    "validate": "npm ls"
+    "validate": "npm ls",
+    "image-size-check": "node scripts/image-size-check.js"
   },
   "jest": {
     "moduleDirectories": [
@@ -128,6 +130,7 @@
   "pre-commit": [
     "fix",
     "format",
-    "lint"
+    "lint",
+    "image-size-check"
   ]
 }

--- a/scripts/image-size-check.js
+++ b/scripts/image-size-check.js
@@ -1,0 +1,22 @@
+/* eslint-disable */
+
+const fs = require('fs')
+const globby = require('globby')
+
+const MAXIMUM_IMAGE_SIZE = 1024 * 1024 // 1MB
+
+async function checkSize(types) {
+  const paths = await globby(types)
+  const oversizedImages = paths.filter(p => {
+    const file = fs.statSync(p)
+    return file.size > MAXIMUM_IMAGE_SIZE
+  })
+
+  if (oversizedImages.length){
+    console.log('Following files are oversized')
+    console.log(oversizedImages)
+    process.exit(-1)
+  }
+
+}
+checkSize(['src/images/**/*.png', 'src/images/**/*.jpg'])


### PR DESCRIPTION
Simple solution to check the image file sizes on `src/images` folder. 
If any of the files exceeds size of `1 MB` it will complain

Fix #676