### PR TITLE
Add .jshintrc and .jshintignore to source control

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,10 @@
+{
+  "node": true,
+
+  "curly": true,
+  "latedef": true,
+  "quotmark": true,
+  "undef": true,
+  "unused": true,
+  "trailing": true
+}


### PR DESCRIPTION
# Description of changes
Adds the default auto-generated `.jshintrc` and `.jshintignore` to source control.

# Issue Resolved
Fixes #682
