### PR TITLE
Adds new image size check as precommit hook

### DIFF
--- a/bin/image-size-check
+++ b/bin/image-size-check
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+get_base_path() {
+  cd $(dirname $0) && cd .. && pwd
+}
+echoerr() { echo "$@" 1>&2; }
+
+BASE_DIR="$(get_base_path)"
+IMAGE_DIR="${BASE_DIR}/src/images/"
+IMAGE_SIZE_THRESHOLD=1M
+
+image_search_result=
+
+new_images=$(git diff --cached --name-only --diff-filter=AM $IMAGE_DIR)
+if [ ! -z "$new_images" ]; then
+  image_search_result=$(echo $new_images | xargs du -ah -t $IMAGE_SIZE_THRESHOLD)
+fi
+
+if [ ! -z "$image_search_result" ]; then
+  echoerr "Error: Found image(s) with size over $IMAGE_SIZE_THRESHOLD"
+  echoerr "${image_search_result}"
+  exit 1
+fi
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "backend": "./bin/run_backend.sh",
-    "validate": "npm ls"
+    "validate": "npm ls",
+    "image-size-check": "./bin/image-size-check"
   },
   "jest": {
     "moduleDirectories": [
@@ -128,6 +129,7 @@
   "pre-commit": [
     "fix",
     "format",
-    "lint"
+    "lint",
+    "image-size-check"
   ]
 }


### PR DESCRIPTION
# Description of changes
This PR adds image size check for files that was Added(A) or Modified(M) into `src/images/` folder. The check itself is invoked by git precommit-hook.

Fixes #676 
