### PR TITLE
Load webfont from link element instead of CSS @import.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="%PUBLIC_URL%/ms-icon-144x144.png">
   <meta name="theme-color" content="#ffffff">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif">
   <script src="https://cdn.ravenjs.com/3.16.0/raven.min.js" crossorigin="anonymous"></script>
 
   <!--

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Noto+Serif');
 @font-face {
   font-family: 'PF Din Display';
   font-weight: normal;


### PR DESCRIPTION
# Description of changes
Using `@import` to load web fonts has some known issues with asset compilation: https://stackoverflow.com/questions/12316501/including-google-web-fonts-link-or-import/12380004#12380004

This MR resolves the "missing fonts" by moving the "Noto Serif" import into a plain old `link` element on the index layout.

There are some Webpack plugins available for this sort of loading, but that seems a little heavy-handed to nab a single font. If you'd prefer to go down that road, let me know and I'll dive in on the additional legwork.

# Issue Resolved
Fixes #701
