### PR TITLE
Clean duplicates from gitignore & ignore precommit-hook defaults.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,11 +51,6 @@ fabric.properties
 ### JetBrains Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
 
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
-
 # Sonarlint plugin
 .idea/sonarlint
 
@@ -140,13 +135,6 @@ GitHub.sublime-settings
 ### WebStorm Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
 
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
-
-# Sonarlint plugin
-
 ### Windows ###
 # Windows thumbnail cache files
 Thumbs.db
@@ -169,12 +157,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/macos,linux,windows,webstorm,jetbrains,sublimetext
-
-
-# Logs
-logs
-*.log
-npm-debug.log*
 
 # Runtime Data
 # Logs
@@ -230,3 +212,7 @@ yarn-error.log*
 .vscode
 
 backend
+
+# precommit-hook package defaults
+.jshintignore
+.jshintrc


### PR DESCRIPTION
# Description of changes
Ignore the `.jshintrc` & `.jshintignore` files generated by the `precommit-hooks` NPM package.

Includes a little bit of .gitignore cleanup as well - looks like `gitignore.io` left some duplicates in their generated code.

# Issue Resolved
Fixes #682
