### PR TITLE
Rework scholarships on front page and pass css as props to image card

### DIFF
--- a/src/scenes/home/landing/whatWeDo/whatWeDo.css
+++ b/src/scenes/home/landing/whatWeDo/whatWeDo.css
@@ -4,3 +4,9 @@
   align-items: center;
   justify-content: space-around;
 }
+
+.scholarshipLink {
+  color: inherit;
+  font-family: inherit;
+  text-decoration: none;
+}

--- a/src/scenes/home/landing/whatWeDo/whatWeDo.js
+++ b/src/scenes/home/landing/whatWeDo/whatWeDo.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Section from 'shared/components/section/section';
 import ImageCard from 'shared/components/imageCard/imageCard';
 import image1 from 'images/General-Couple-Computer.jpg';
 import image2 from 'images/General-Group-Coffee.jpg';
-import image3 from 'images/ThinkstockPhotos-489787502.jpg';
-import image4 from 'images/rhs2017_photo.jpg';
+import image3 from 'images/rhs2017_photo.jpg';
+import image4 from 'images/ThinkstockPhotos-489787502.jpg';
 import content from './whatWeDoContent.json';
 import styles from './whatWeDo.css';
 
@@ -15,21 +16,43 @@ const WhatWeDo = () => (
         image={image1}
         title={content.items[0].title}
         cardText={content.items[0].body}
+        cardHeight={225}
+        cardWidth={650}
+        textWidth={275}
+        imageHeight={225}
+        imageWidth={325}
       />
       <ImageCard
         image={image2}
         title={content.items[1].title}
         cardText={content.items[1].body}
+        cardHeight={225}
+        cardWidth={650}
+        textWidth={275}
+        imageHeight={225}
+        imageWidth={325}
       />
-      <ImageCard
-        image={image3}
-        title={content.items[2].title}
-        cardText={content.items[2].body}
-      />
+      <Link to="/code_schools" className={styles.scholarshipLink}>
+        <ImageCard
+          image={image3}
+          title={content.items[2].title}
+          cardText={content.items[2].body}
+          cardHeight={225}
+          cardWidth={650}
+          textWidth={275}
+          imageHeight={225}
+          imageWidth={325}
+        />
+      </Link>
       <ImageCard
         image={image4}
         title={content.items[3].title}
         cardText={content.items[3].body}
+        cardHeight={225}
+        cardWidth={650}
+        textWidth={275}
+        imageHeight={225}
+        imageWidth={325}
       />
     </div>
   </Section>

--- a/src/scenes/home/landing/whatWeDo/whatWeDoContent.json
+++ b/src/scenes/home/landing/whatWeDo/whatWeDoContent.json
@@ -15,18 +15,18 @@
       "imageUrl": "images/General-Group-Coffee.jpg"
     },
     {
+      "title": "Scholarships",
+      "body": "Our scholarships provide opportunities for the military community to kickstart their careers in software development. We partner with tech conferences around the country and offer scholarship tickets to events throughout the year, as well as partial and full tuition scholarships to coding bootcamps.",
+      "buttonText": "View Past Events",
+      "linkTo": "/pastEvents",
+      "imageUrl": "images/rhs2017_photo.jpg"
+    },
+    {
       "title": "Conference Scholarships",
       "body": "We partner with tech conferences around the country and offers scholarship tickets to events throughout the year.",
       "buttonText": "View Past Events",
       "linkTo": "/pastEvents",
       "imageUrl": "images/ThinkstockPhotos-489787502.jpg"
-    },
-    {
-      "title": "Code School Scholarships",
-      "body": "Our scholarships to code schools provide opportunities for the military community to kickstart their careers in software development.",
-      "buttonText": "View Past Events",
-      "linkTo": "/pastEvents",
-      "imageUrl": "images/rhs2017_photo.jpg"
     }
   ]
 }

--- a/src/shared/components/imageCard/imageCard.css
+++ b/src/shared/components/imageCard/imageCard.css
@@ -1,6 +1,4 @@
 .imageCard {
-  width: 600px;
-  height: 200px;
   margin: 15px;
   display: flex;
   flex-flow: row wrap;
@@ -11,11 +9,6 @@
 .image {
   height: 200px;
   width: 300px;
-}
-
-.cardImage {
-  width: 300px;
-  height: 200px;
 }
 
 .cardText {
@@ -41,8 +34,8 @@
 /* Vertical space between cards for vertical layout */
 @media screen and (max-width: 667px) {
   .imageCard {
-    height: 400px;
-    width: 300px;
+    height: 400px !important;
+    width: 300px !important;
   }
 
   .cardText > h6 {

--- a/src/shared/components/imageCard/imageCard.js
+++ b/src/shared/components/imageCard/imageCard.js
@@ -8,12 +8,17 @@ const ImageCard = ({
   cardText,
   image,
   link,
-  title
+  title,
+  cardHeight,
+  cardWidth,
+  textWidth,
+  imageHeight,
+  imageWidth
 }) => (
-  <div className={styles.imageCard}>
-    <img className={styles.cardImage} src={image} alt={title} />
+  <div className={styles.imageCard} style={{ height: cardHeight, width: cardWidth }}>
+    <img className={styles.cardImage} src={image} alt={title} style={{ height: imageHeight, width: imageWidth }} />
 
-    <div className={styles.cardText}>
+    <div className={styles.cardText} style={{ width: textWidth }}>
       <h6>{title}</h6>
       <p>{cardText}</p>
       {link &&
@@ -32,11 +37,21 @@ ImageCard.propTypes = {
   cardText: PropTypes.string.isRequired,
   buttonText: PropTypes.string,
   link: PropTypes.string,
+  cardHeight: PropTypes.number,
+  cardWidth: PropTypes.number,
+  textWidth: PropTypes.number,
+  imageHeight: PropTypes.number,
+  imageWidth: PropTypes.number
 };
 
 ImageCard.defaultProps = {
   link: null,
   buttonText: null,
+  cardHeight: 200,
+  cardWidth: 600,
+  textWidth: 250,
+  imageHeight: 200,
+  imageWidth: 300
 };
 
 export default ImageCard;


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
1. Moves 'Code School Scholarships' before 'Conference Scholarships'
2. Updates the language in the Code School Scholarships
3. Updates the 'Code School Scholarships' title to 'Scholarships'
4. Links the image to the Code Schools page

In order to make this work, the Image Card needed to have some size adjustments (per discussion in #717). This made the Image Card component quite a bit longer, but you can now pass the following props to the Image Card:
- cardHeight
- cardWidth
- textWidth
- imageHeight
- imageWidth

These values are defaulted to what was used previously, so if no props are passed it will work exactly as it did before. I did my best to adjust the sizes so that the aspect ratio of the images were retained.

One additional issue that arose was that passing the css as props overrode the media query that stacks the cards on smaller screens, so it was broken on mobile. My temporary fix for this was to add `!important!` on the media query styles - let me know if you think of a better way around this.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #715 
