### PR TITLE
adds maintainers information to the repo

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,7 @@ Check out [how Operation Code Open Source projects are maintained](https://githu
 
 * [Kyle Holmberg](http://www.github.com/kylemh)
 
-# Lieutenant
+# Sergeant
 
 * [Evan Cooper](http://www.github.com/cooperbuilt)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,17 @@
+# Maintainers 
+
+This file lists how the Operation Code Front End project is maintained. When making changes to the system, this file tells you who needs to review your contribution - you need a simple majority of maintainers for the relevant subsystems to provide a 👍 on your pull request. Additionally, you need to not receive a veto from a Lieutenant or the Project Lead.
+
+Check out [how Operation Code Open Source projects are maintained](https://github.com/OperationCode/START_HERE/blob/61cebc02875ef448679e1130d3a68ef2f855d6c4/open_source_maintenance_policy.md) for details on the process, how to become a maintainer, lieutenant, or the project lead.
+
+# Project Lead
+
+* [Kyle Holmberg](http://www.github.com/kylemh)
+
+# Lieutenant
+
+* [Evan Cooper](http://www.github.com/cooperbuilt)
+
+# Maintainers
+
+* [Kelly MacLeod](http://www.github.com/ksmacleod99)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 Welcome to our frontend repository built using React and Express! Please look forward to an increased amount of documentation and tickets. We highly recommend [joining our organization](https://operationcode.org/join) to receive an invite to our Slack team. From there, you'll want to join the `#oc-projects` channel. You can get help from multiple professional developers and people who have worked on the application since day 1!
 
+For information about the maintainers of the project, check out [MAINTAINERS.md](MAINTAINERS.md).
+
 ### Quick Start
 
 Prerequisites:


### PR DESCRIPTION
# Description of changes
This adds in a maintainers file in line with our [newly adopted Open Source maintenance policy](https://github.com/OperationCode/START_HERE/blob/61cebc02875ef448679e1130d3a68ef2f855d6c4/open_source_maintenance_policy.md)
