### PR TITLE
Adding image-size check script and pre-commit hook to run it

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,19 +92,13 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "backend": "./bin/run_backend.sh",
-    "validate": "npm ls"
+    "validate": "npm ls",
+    "image-size": "node scripts/imageSize.js"
   },
   "jest": {
-    "moduleDirectories": [
-      "node_modules",
-      "src"
-    ],
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/polyfills.js"
-    ],
+    "moduleDirectories": ["node_modules", "src"],
+    "collectCoverageFrom": ["src/**/*.{js,jsx}"],
+    "setupFiles": ["<rootDir>/config/polyfills.js"],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.js?(x)",
       "<rootDir>/src/**/?(*.)(spec|test).js?(x)"
@@ -116,22 +110,14 @@
       "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
+    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
     "moduleNameMapper": {
       "^react-native$": "react-native-web"
     }
   },
   "babel": {
-    "presets": [
-      "react-app"
-    ]
+    "presets": ["react-app"]
   },
   "homepage": "http://frontend.operationcode.org/",
-  "pre-commit": [
-    "fix",
-    "format",
-    "lint"
-  ]
+  "pre-commit": ["fix", "format", "lint", "image-size"]
 }

--- a/scripts/imageSize.js
+++ b/scripts/imageSize.js
@@ -2,30 +2,27 @@
 const path = require('path');
 const fs = require('fs');
 
-let fileArray = [];
-
-const read = dir =>
+const readImageDirectory = dir =>
   fs
     .readdirSync(dir)
     .reduce(
-      (files, file) =>
-        fs.statSync(path.join(dir, file)).isDirectory()
-          ? files.concat(read(path.join(dir, file)))
-          : files.concat(path.join(dir, file)),
-      []
+    (files, file) =>
+      fs.statSync(path.join(dir, file)).isDirectory()
+        ? files.concat(readImageDirectory(path.join(dir, file)))
+        : files.concat(path.join(dir, file)),
+    []
     )
     .filter(file => typeof file === 'string')
-    .map(image => {
-      if (fs.lstatSync(image).size > 1000000) {
-        fileArray.push(image);
-      }
+    .filter(image => {
+      fs.lstatSync(image).size > 1000000;
     });
 
-read('src/images/');
+const fileArray = readImageDirectory('src/images/');
 
-if (fileArray.length > 0) {
+if (fileArray.length) {
   console.log(`The following image(s) are over our 1MB size limit: ${fileArray}`);
   process.exit(-1);
 } else {
+  console.log('Test successful 💪 💪 💪 💪 💪 💪');
   process.exit(0);
 }

--- a/scripts/imageSize.js
+++ b/scripts/imageSize.js
@@ -1,0 +1,31 @@
+/* eslint-disable */
+const path = require('path');
+const fs = require('fs');
+
+let fileArray = [];
+
+const read = dir =>
+  fs
+    .readdirSync(dir)
+    .reduce(
+      (files, file) =>
+        fs.statSync(path.join(dir, file)).isDirectory()
+          ? files.concat(read(path.join(dir, file)))
+          : files.concat(path.join(dir, file)),
+      []
+    )
+    .filter(file => typeof file === 'string')
+    .map(image => {
+      if (fs.lstatSync(image).size > 1000000) {
+        fileArray.push(image);
+      }
+    });
+
+read('src/images/');
+
+if (fileArray.length > 0) {
+  console.log(`The following image(s) are over our 1MB size limit: ${fileArray}`);
+  process.exit(-1);
+} else {
+  process.exit(0);
+}


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Adds a pre-commit hook that recursively checks all images within the src/images folder. If they are above the 1MB size limit, this hook will console log the offending files and fail the commit.

## Note:
In order to get this to PR, I ran my commit with a --no-verify flag because we have two offending files. `src/images/serviceSeals/USMCReserve.png` and `src/images/Family-2.png`. I will open a new issue to resize these images. 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #676 
