### PR TITLE
Add email signup form to the bottom of lander

### DIFF
--- a/src/scenes/home/home.js
+++ b/src/scenes/home/home.js
@@ -235,7 +235,7 @@ class Home extends Component {
               exact
               path="/"
               render={props => (
-                <Landing {...props} />
+                <Landing {...props} sendNotification={this.sendNotification} />
               )}
             />
             <Route

--- a/src/scenes/home/landing/emailSignup/emailSignup.css
+++ b/src/scenes/home/landing/emailSignup/emailSignup.css
@@ -1,0 +1,20 @@
+.emailSignup {
+  width: 80%;
+}
+
+.emailListForm {
+  justify-content: center;
+  align-items: center;
+}
+
+.emailInput {
+  margin-bottom: 16px;
+  width: 20em;
+}
+
+.emailSignupText {
+  max-width: 700px;
+  font-size: 20px;
+}
+
+

--- a/src/scenes/home/landing/emailSignup/emailSignup.js
+++ b/src/scenes/home/landing/emailSignup/emailSignup.js
@@ -31,9 +31,7 @@ class EmailSignup extends Component {
 
     if (this.isFormValid()) {
       const { email } = this.state;
-      axios.post(`${config.backendUrl}/email_list_recipients`, {
-        user: { email }
-      }).then(() => {
+      axios.post(`${config.backendUrl}/email_list_recipients`, `email=${email}`).then(() => {
         this.setState({ isLoading: false });
         this.props.sendNotification('');
       }).catch((error) => {

--- a/src/scenes/home/landing/emailSignup/emailSignup.js
+++ b/src/scenes/home/landing/emailSignup/emailSignup.js
@@ -1,0 +1,94 @@
+import React, { Component } from 'react';
+import Section from 'shared/components/section/section';
+import axios from 'axios';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import config from 'config/environment';
+import Form from 'shared/components/form/form';
+import FormEmail from 'shared/components/form/formEmail/formEmail';
+import FormButton from 'shared/components/form/formButton/formButton';
+import styles from './emailSignup.css';
+
+class EmailSignup extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      email: '',
+      emailValid: false,
+      success: false,
+      isLoading: false
+    };
+  }
+
+  onEmailChange = (value, valid) => {
+    this.setState({ email: value.toLowerCase(), emailValid: valid });
+  }
+
+  handleOnClick = (e) => {
+    e.preventDefault();
+
+    this.setState({ isLoading: true });
+
+    if (this.isFormValid()) {
+      const { email } = this.state;
+      axios.post(`${config.backendUrl}/email_list_recipients`, {
+        user: { email }
+      }).then(() => {
+        this.setState({ isLoading: false });
+        this.props.sendNotification('');
+      }).catch((error) => {
+        const data = _.get(error, 'response.data');
+        let errorMessage = '';
+        if (data) {
+          Object.keys(data).forEach((key) => {
+            if (data && data.hasOwnProperty(key)) { // eslint-disable-line
+              errorMessage += ` ${key}: ${data[key][0]} `;
+            }
+          });
+        }
+        this.props.sendNotification('error', 'Error', 'Please try signing up again. Contact one of our staff if this problem persists.');
+        this.setState({ error: errorMessage, isLoading: false });
+      });
+    } else {
+      this.setState({ error: 'Missing required field(s)', isLoading: false });
+    }
+  }
+
+  isFormValid = () =>
+    this.state.emailValid;
+
+  render() {
+    return (
+      <Section
+        title="Sign Up For Our Mailing List"
+        className={styles.emailSignup}
+        theme="white"
+        headingLines={false}
+      >
+        <p className={styles.emailSignupText}>
+          Keep up to date with everything Operation Code. We proimse we won&#39;t spam you or sell your information.
+        </p>
+        <Form className={styles.emailListForm}>
+          <div className={styles.emailInput}>
+            <FormEmail
+              id="email" placeholder="Email"
+              onChange={this.onEmailChange}
+              ref={(child) => { this.emailRef = child; }}
+            />
+          </div>
+          {this.state.error &&
+            <ul className={styles.errorList}>There was an error joining Operation Code:
+              <li className={styles.errorMessage}>{this.state.error}</li>
+            </ul>}
+          {this.state.isLoading ? <FormButton className={styles.joinButton} text="Loading..." disabled theme="grey" /> : <FormButton className={styles.joinButton} text="Sign Up" onClick={this.handleOnClick} theme="blue" />}
+        </Form>
+      </Section >
+    );
+  }
+}
+
+EmailSignup.propTypes = {
+  sendNotification: PropTypes.func.isRequired
+};
+
+export default EmailSignup;

--- a/src/scenes/home/landing/landing.js
+++ b/src/scenes/home/landing/landing.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 import { FaClose } from 'react-icons/lib/fa';
 import LinkButton from 'shared/components/linkButton/linkButton';
@@ -9,6 +10,8 @@ import SuccessStories from './successStories/successStories';
 import Partners from './partners/partners';
 import Donate from '../../../shared/components/donate/donate';
 import Join from '../../../shared/components/join/join';
+import EmailSignup from './emailSignup/emailSignup';
+
 import styles from './landing.css';
 
 class Landing extends Component {
@@ -66,9 +69,14 @@ class Landing extends Component {
         <Partners />
         <Donate />
         <Join />
+        <EmailSignup sendNotification={this.props.sendNotification} />
       </div>
     );
   }
 }
+
+Landing.propTypes = {
+  sendNotification: PropTypes.func.isRequired
+};
 
 export default Landing;


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
This PR adds a simple email signup form to the end of the homepage. Its functionality mirrors  our normal signup component in the following ways:
1. The button pauses while the action resolves
2. The user is provided with error messaging should any arise
3. A flash notification pops with an error

## Full-Stack Testing
This was successfully tested with our backend (until I broke something with docker), however, it definitely deserves more thorough full-stack testing.

## Visual Testing
Certified Responsive™ on firefox, chrome, and safari (on breakpoints down to ~330px)

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #745 
