### PR TITLE
stop showing the pop-up in case the credentials are wrong

### DIFF
--- a/src/shared/components/login/login.js
+++ b/src/shared/components/login/login.js
@@ -148,7 +148,11 @@ class Login extends Component {
           });
         })
         .catch((error) => {
-          this.props.sendNotification('error', 'Error', 'We will investigate this issue!');
+          const statusCode = error.response.status;
+          if (statusCode !== 401) {
+            this.props.sendNotification('error', 'Error', 'We will investigate this issue!');
+          }
+
           this.setErrorMessage(error);
         });
     }

--- a/src/shared/components/login/login.js
+++ b/src/shared/components/login/login.js
@@ -148,7 +148,7 @@ class Login extends Component {
           });
         })
         .catch((error) => {
-          if (error.response.status !== 401) {
+          if (_.get(error, ['response', 'status'], -1) !== 401) {
             this.props.sendNotification('error', 'Error', 'We will investigate this issue!');
           }
 

--- a/src/shared/components/login/login.js
+++ b/src/shared/components/login/login.js
@@ -148,8 +148,7 @@ class Login extends Component {
           });
         })
         .catch((error) => {
-          const statusCode = error.response.status;
-          if (statusCode !== 401) {
+          if (error.response.status !== 401) {
             this.props.sendNotification('error', 'Error', 'We will investigate this issue!');
           }
 


### PR DESCRIPTION
# Description of changes
Do not display the pop-up error message if the credentials that were given are incorrect.

# Issue Resolved
Fixes #776 
