### PR TITLE
Prevents verified user from being presented ID.me verification request

### DIFF
--- a/src/scenes/home/profile/profile.js
+++ b/src/scenes/home/profile/profile.js
@@ -16,13 +16,13 @@ const Profile = ({ verified }) => (
         <IconCard
           title="Request a Mentor"
           fontAwesomeIcon="FaLifeBouy"
-          url="https://op.co.de/mentor-request"
+          url={verified ? 'https://op.co.de/mentor-request' : ''}
         />
 
         <IconCard
           title="Check for Scholarships"
           fontAwesomeIcon="FaGraduationCap"
-          url="/scholarships"
+          url={verified ? '/scholarships' : ''}
         />
 
         <IconCard title="Check for Open Jobs" fontAwesomeIcon="FaBriefcase" url="/jobs" />

--- a/src/scenes/home/profile/profile.js
+++ b/src/scenes/home/profile/profile.js
@@ -8,23 +8,32 @@ import styles from './profile.css';
 const Profile = ({ verified }) => (
   <Section title="My Profile" theme="gray">
     <div className={verified ? styles.profileContainer_verified : styles.profileContainer}>
+
+      {verified && (
+        <div
+          className={
+            verified ? styles.profileContainer__cards_verified : styles.profileContainer__cards
+          }
+        >
+          <IconCard
+            title="Request a Mentor"
+            fontAwesomeIcon="FaLifeBouy"
+            url="https://op.co.de/mentor-request"
+          />
+
+          <IconCard
+            title="Check for Scholarships"
+            fontAwesomeIcon="FaGraduationCap"
+            url="/scholarships"
+          />
+        </div>
+      )}
+
       <div
         className={
           verified ? styles.profileContainer__cards_verified : styles.profileContainer__cards
         }
       >
-        <IconCard
-          title="Request a Mentor"
-          fontAwesomeIcon="FaLifeBouy"
-          url={verified ? 'https://op.co.de/mentor-request' : ''}
-        />
-
-        <IconCard
-          title="Check for Scholarships"
-          fontAwesomeIcon="FaGraduationCap"
-          url={verified ? '/scholarships' : ''}
-        />
-
         <IconCard title="Check for Open Jobs" fontAwesomeIcon="FaBriefcase" url="/jobs" />
 
         <IconCard

--- a/src/shared/components/idme/idmeverify/idmeverify.js
+++ b/src/shared/components/idme/idmeverify/idmeverify.js
@@ -6,6 +6,7 @@ import { withRouter } from 'react-router-dom';
 import Section from 'shared/components/section/section';
 import _ from 'lodash';
 import styles from './idmeverify.css';
+import * as CookieHelpers from '../../../utils/cookieHelper';
 
 class IdmeVerify extends Component {
   constructor() {
@@ -20,6 +21,7 @@ class IdmeVerify extends Component {
       postBackend('users/profile/verify', { access_token: qs.access_token }).then((response) => {
         if (_.get(response, 'data.verified')) {
           this.setState({ verified: true });
+          CookieHelpers.setVerified(true);
           this.props.updateRootAuthState();
         }
       }).catch(() => {

--- a/src/shared/components/idme/idmeverify/idmeverify.js
+++ b/src/shared/components/idme/idmeverify/idmeverify.js
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router-dom';
 import Section from 'shared/components/section/section';
 import _ from 'lodash';
 import styles from './idmeverify.css';
-import * as CookieHelpers from '../../../utils/cookieHelper';
+import { setUserVerifiedCookie } from '../../../utils/cookieHelper';
 
 class IdmeVerify extends Component {
   constructor() {
@@ -20,8 +20,8 @@ class IdmeVerify extends Component {
     } else if (qs.access_token) {
       postBackend('users/profile/verify', { access_token: qs.access_token }).then((response) => {
         if (_.get(response, 'data.verified')) {
+          setUserVerifiedCookie(true);
           this.setState({ verified: true });
-          CookieHelpers.setVerified(true);
           this.props.updateRootAuthState();
         }
       }).catch(() => {

--- a/src/shared/utils/cookieHelper.js
+++ b/src/shared/utils/cookieHelper.js
@@ -20,6 +20,11 @@ export const setUserAuthCookie = ({ token, user }) => {
   cookies.set('verified', user.verified, cookieOptions);
 };
 
+export const setVerified = (verified) => {
+  const cookies = new Cookies();
+  cookies.set('verified', verified, cookieOptions);
+};
+
 export const clearAuthCookies = () => {
   const cookies = new Cookies();
   cookies.remove('token', cookieOptions);

--- a/src/shared/utils/cookieHelper.js
+++ b/src/shared/utils/cookieHelper.js
@@ -20,9 +20,9 @@ export const setUserAuthCookie = ({ token, user }) => {
   cookies.set('verified', user.verified, cookieOptions);
 };
 
-export const setVerified = (verified) => {
+export const setUserVerifiedCookie = (isVerified) => {
   const cookies = new Cookies();
-  cookies.set('verified', verified, cookieOptions);
+  cookies.set('verified', isVerified, cookieOptions);
 };
 
 export const clearAuthCookies = () => {


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->

- Modifies `IdmeVerify` to set the `verified` cookie preventing a verified user from being presented the ID.me button #767

- Disables links for mentor and scholarship requests on the profile page unless user is verified #765 

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #767 


  