### PR TITLE
updated code schools object error

### DIFF
--- a/src/scenes/home/codeSchools/partnerSchools/partnerSchools.js
+++ b/src/scenes/home/codeSchools/partnerSchools/partnerSchools.js
@@ -22,9 +22,11 @@ class PartnerSchools extends Component {
         margin1
       >
         <p>
-          Many code schools around the nation offer military/veterans discounts to make coding education more accessible to our veterans.
+          Many code schools around the nation offer military/veterans discounts
+          to make coding education more accessible to our veterans.
           <br />
-          We&apos;ve partnered up with those schools in order to help direct veterans to the best code schools around the country.
+          We&apos;ve partnered up with those schools in order to help direct
+          veterans to the best code schools around the country.
           <br />
           <br />
           <b>Apply for a scholarship with our partners now and get coding:</b>
@@ -133,9 +135,7 @@ class PartnerSchools extends Component {
           <p>
             Are you a code school seeking a partnership with Operation Code?
             <br />
-            <a href="mailto:staff@operationcode.org">
-              Reach out to us!
-            </a>
+            <a href="mailto:staff@operationcode.org">Reach out to us!</a>
           </p>
         </div>
       </Section>

--- a/src/shared/components/schoolCard/schoolCard.js
+++ b/src/shared/components/schoolCard/schoolCard.js
@@ -12,7 +12,7 @@ const SchoolCard = ({
   schoolAddress,
   schoolCity,
   schoolName,
-  schoolState,
+  schoolState
 }) => (
   <div className={styles.schoolCard}>
     <div className={styles.schoolCardImage}>
@@ -30,9 +30,11 @@ const SchoolCard = ({
         </span>
         <br />
         <span className={styles.schoolLocation}>
-          {schoolAddress.includes('Online')
-            ? `Online Available ${<br />}`
-            : null}
+          {schoolAddress.includes('Online') ? (
+            <text>
+              Online Available<br />
+            </text>
+          ) : null}
           {schoolCity}
           {schoolCity ? ', ' : null}
           {schoolState}
@@ -62,12 +64,12 @@ SchoolCard.propTypes = {
   logo: PropTypes.string.isRequired,
   GI: PropTypes.string.isRequired,
   fullTime: PropTypes.string.isRequired,
-  hardware: PropTypes.string.isRequired,
+  hardware: PropTypes.string.isRequired
 };
 
 SchoolCard.defaultProps = {
   schoolCity: null,
-  schoolState: null,
+  schoolState: null
 };
 
 export default SchoolCard;


### PR DESCRIPTION
# removes the object error when trying to render code school is online. 
<!-- What does this PR change and why -->

# code school rendering
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
When the code school was previously rendering the ternary would sometimes insert a javascript object instead of text. 
