### PR TITLE
Attempt to prevent build problems from yarn registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ WORKDIR /usr/src/app
 # Install app dependencies
 COPY package.json /usr/src/app/
 COPY yarn.lock /usr/src/app/
+
+# Set registry to NPM's in attempt to avoid build issues
+RUN npm config set registry "https://registry.npmjs.org"
+
+# Install front-end dependencies
 RUN yarn install --no-progress
 
 # Bundle app source


### PR DESCRIPTION
# Description of changes
Attempting to change the registry to NPM (more dependable) in order to prevent lame build errors from Travis.

Source: https://github.com/yarnpkg/yarn/issues/1565#issuecomment-300822879