### PR TITLE
/bug: prevent flash auth-required content

### DIFF
--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -13,7 +13,7 @@ class MentorRequest extends Component {
   state = {
     mentors: [],
     services: [],
-    loggedIn: true
+    loggedIn: false
   };
 
   componentDidMount() {


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Changed the default in `/mentor-request` such that it doesn't prematurely render prior to verifying logged in. 

# some routes not requiring auth
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #818 

Set's the default state to not logged in so we don't show content. Eventually should move this and other authentication required components behind the `AuthenticatedRoute` component. 
