### PR TITLE
Fix footer layout

### DIFF
--- a/src/scenes/home/branding/logos/logos.css
+++ b/src/scenes/home/branding/logos/logos.css
@@ -19,7 +19,7 @@
   text-align: justify;
 }
 
-a {
+.logosInfo a {
   color: #249cbc;
   font-size: 1.3rem;
   text-decoration: none;

--- a/src/scenes/home/branding/logos/logos.js
+++ b/src/scenes/home/branding/logos/logos.js
@@ -36,7 +36,7 @@ const LogosSection = () => (
       In most cases, use the blue-accent version of the logo. The red-accent is
       delivered for special uses only.
     </p>
-    <p>
+    <p className={styles.logosInfo}>
       <a href="https://ocbranding.squarespace.com/s/Operation-Code-Logo.eps">
         Download master EPS file
       </a>

--- a/src/scenes/home/footer/footer.css
+++ b/src/scenes/home/footer/footer.css
@@ -12,8 +12,17 @@
   height: 100%;
 }
 
-/* outerFooterGroups class represents the NON logo columns of the footer flex container */
-.outerFooterGroups {
+/* outerFooterGroup class represents the NON logo columns of the footer flex container */
+.outerFooterGroupLinks {
+  display: flex;
+  flex: 1 0 30%;
+  flex-flow: row wrap;
+  padding: 64px 0;
+  justify-content: flex-start;
+  align-items: center;
+  overflow: hidden;
+}
+.outerFooterGroupSocial {
   display: flex;
   flex: 1 0 30%;
   flex-flow: column wrap;
@@ -49,15 +58,15 @@
 .blockGroup {
   display: flex;
   flex: 1 0 50%;
-  flex-flow: row wrap;
-  align-items: center;
+  flex-flow: column wrap;
+  align-items: flex-start;
   justify-content: space-around;
 }
 
 .blockGroup a {
   text-decoration: none;
   color: #F7F7F7;
-  padding: 0 30px;
+  margin: 5px 0px;
 }
 
 .blockGroup a:hover {
@@ -78,7 +87,8 @@
 }
 
 @media screen and (max-width: 1330px) {
-  .outerFooterGroups {
+  .outerFooterGroupSocial,
+  .outerFooterGroupLinks {
     flex: 1 0 35%;
   }
 
@@ -101,6 +111,10 @@
   .logo > p {
     font-size: 0.7rem;
   }
+
+  .blockGroup {
+    font-size: 1.2rem;
+  }
 }
 
 @media screen and (max-width: 768px) {
@@ -110,12 +124,12 @@
 }
 
 @media screen and (min-width: 481px) and (max-width: 768px) {
-  .outerFooterGroups {
-    padding: 32px 0;
+  .outerFooterGroupSocial,
+  .outerFooterGroupLinks {
+    padding: 10px 0;
   }
 
   .blockGroup {
-    flex-direction: column;
     height: 100%;
   }
 }
@@ -132,7 +146,7 @@
 
 @media screen and (max-width: 480px) {
   .footer {
-    height: 500px;
+    height: 550px;
     padding: 0 16px;
   }
 
@@ -140,7 +154,8 @@
     display: block;
   }
 
-  .outerFooterGroups {
+  .outerFooterGroupSocial,
+  .outerFooterGroupLinks {
     justify-content: center;
     flex: 1 0 auto;
     padding: 20px 0;
@@ -160,10 +175,7 @@
   }
 
   .blockGroup a {
-    padding: 10px 10px;
+    padding: 0px 0px 0px 30px;
   }
 
-  .blockGroup ~ .blockGroup {
-    margin-top: 10px;
-  }
 }

--- a/src/scenes/home/footer/footer.css
+++ b/src/scenes/home/footer/footer.css
@@ -3,6 +3,7 @@
   height: 250px;
   padding: 0 20px;
   position: relative;
+  font-size: 1.1rem;
 }
 
 .content {
@@ -12,7 +13,7 @@
   height: 100%;
 }
 
-/* outerFooterGroup class represents the NON logo columns of the footer flex container */
+/* outerFooterGroup classes represent the NON logo columns of the footer flex container */
 .outerFooterGroupLinks {
   display: flex;
   flex: 1 0 30%;
@@ -61,12 +62,14 @@
   flex-flow: column wrap;
   align-items: flex-start;
   justify-content: space-around;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .blockGroup a {
   text-decoration: none;
   color: #F7F7F7;
-  margin: 5px 0px;
+  margin: 0.75rem 0px;
 }
 
 .blockGroup a:hover {
@@ -111,42 +114,11 @@
   .logo > p {
     font-size: 0.7rem;
   }
-
-  .blockGroup {
-    font-size: 1.2rem;
-  }
 }
 
 @media screen and (max-width: 768px) {
-  .logo > p {
-    font-size: 0.5rem;
-  }
-}
-
-@media screen and (min-width: 481px) and (max-width: 768px) {
-  .outerFooterGroupSocial,
-  .outerFooterGroupLinks {
-    padding: 10px 0;
-  }
-
-  .blockGroup {
-    height: 100%;
-  }
-}
-
-@media screen and (max-width: 616px) {
-  .email {
-    font-size: 0.8rem;
-  }
-
-  .blockRow a {
-    padding: 10px 10px;
-  }
-}
-
-@media screen and (max-width: 480px) {
   .footer {
-    height: 550px;
+    height: 600px;
     padding: 0 16px;
   }
 
@@ -158,7 +130,7 @@
   .outerFooterGroupLinks {
     justify-content: center;
     flex: 1 0 auto;
-    padding: 20px 0;
+    padding: 5px 0px;
   }
 
   .email {
@@ -175,7 +147,23 @@
   }
 
   .blockGroup a {
-    padding: 0px 0px 0px 30px;
+    padding: 0px 0px 0px 6rem;
+    font-size: 1.3rem;
+  }
+}
+
+@media screen and (max-width: 616px) {
+  .blockRow a {
+    padding: 10px 10px;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .blockGroup a {
+    padding-left: 3rem;
   }
 
+  .footer {
+    padding-bottom: 50px;
+  }
 }

--- a/src/scenes/home/footer/footer.css
+++ b/src/scenes/home/footer/footer.css
@@ -1,6 +1,6 @@
 .footer {
-  background-color: #4A4A4A;
-  height: 250px;
+  background-color: #4a4a4a;
+  height: 300px;
   padding: 0 20px;
   position: relative;
   font-size: 1.1rem;
@@ -39,7 +39,7 @@
 }
 
 .email a {
-  color: #F7F7F7;
+  color: #f7f7f7;
   text-align: center;
   text-decoration: none;
 }
@@ -68,7 +68,7 @@
 
 .blockGroup a {
   text-decoration: none;
-  color: #F7F7F7;
+  color: #f7f7f7;
   margin: 0.75rem 0px;
 }
 
@@ -78,7 +78,7 @@
 }
 
 .copyright {
-  color:#F7F7F7;
+  color: #f7f7f7;
   font-size: inherit;
   font-family: 'PF Din Display';
   text-align: center;
@@ -106,7 +106,7 @@
   }
 }
 
-@media screen and (min-width: 481px) and (max-width: 979px) {
+@media screen and (min-width: 481px) and (max-width: 1100px) {
   .logo > img {
     height: 100px;
   }
@@ -118,8 +118,8 @@
 
 @media screen and (max-width: 768px) {
   .footer {
-    height: 600px;
-    padding: 0 16px;
+    height: 700px;
+    padding: 2rem 1rem 1rem 1rem;
   }
 
   .content {
@@ -138,8 +138,18 @@
     margin-bottom: 10px;
   }
 
+  .logo {
+    margin: 1rem 0;
+  }
+
+  .copyright {
+    margin: 0;
+  }
+
   .logo img {
     height: 100px;
+    line-height: 1.5;
+    margin: 0 0 1rem 0;
   }
 
   .blockGroup {
@@ -155,6 +165,10 @@
 @media screen and (max-width: 616px) {
   .blockRow a {
     padding: 10px 10px;
+  }
+
+  .footer {
+    height: 650px;
   }
 }
 

--- a/src/scenes/home/footer/footer.js
+++ b/src/scenes/home/footer/footer.js
@@ -8,7 +8,7 @@ import styles from './footer.css';
 const Footer = () => (
   <div className={styles.footer}>
     <div className={styles.content}>
-      <div className={styles.outerFooterGroups}>
+      <div className={styles.outerFooterGroupSocial}>
         <div className={styles.email} >
           <a href="mailto:contact@operationcode.org">contact@operationcode.org</a>
         </div>
@@ -22,7 +22,7 @@ const Footer = () => (
           Operation Code™
         </p>
       </div>
-      <div className={styles.outerFooterGroups}>
+      <div className={styles.outerFooterGroupLinks}>
         <div className={styles.blockGroup} >
           <Link to="/about">About</Link>
           <Link to="/press">Press</Link>


### PR DESCRIPTION
# Description of changes
Currently, the layout of the footer links makes them look haphazard, and sometimes unusable, so I'm working to correct that. The links section of the footer jsx contains 2 blockGroups of 5 links each, so I kept these and styled them into 2 columns, mainly by adjusting flex and padding properties. I also changed the 2 outerFooterGroups into 1 outerFooterGroupSocial and 1 outerFooterGroupLinks so that they could be styled separately.

With my changes, the links look good at screen widths <480px and >810px. I'm still working on the in-between range. At these widths, some links wrap to 2 lines, disrupting the alignment and cutting off the bottom link. I don't want to make the text much smaller, so I'm thinking it may be best to adjust the media queries so that the footer elements stack vertically below about 810px, instead of below 480px. Would that be alright, @kylemh? That would also resolve the issue of the email address being cut-off at intermediate screen widths. To reduce blank space, the 4 social buttons could be kept on 1 line.

Per your suggestion, I added some more padding between the links, but I didn't do the full 1rem because it seemed like too much. Let me know if you think it needs more. Thanks for your help!

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #816 

# Screenshots
1300 px:
![screen shot 2018-01-23 at 5 13 37 pm](https://user-images.githubusercontent.com/17550347/35303789-306e926a-0061-11e8-9d62-cacd2ba81598.png)
650px:
![screen shot 2018-01-23 at 5 14 47 pm](https://user-images.githubusercontent.com/17550347/35303803-40511518-0061-11e8-8aee-9d308670b85e.png)
470px:
![screen shot 2018-01-23 at 5 15 06 pm](https://user-images.githubusercontent.com/17550347/35303815-4c5ec382-0061-11e8-917b-00f4fe66ea43.png)


