### PR TITLE
Disable boardcard animations for mobile.

### DIFF
--- a/src/scenes/home/team/team.js
+++ b/src/scenes/home/team/team.js
@@ -31,6 +31,7 @@ class Team extends Component {
 
     const boardMembers = BoardMembers.map(boardMember => (
       <BoardCard
+        key={`${Math.random()} + ${boardMember.name}`}
         name={boardMember.name}
         role={boardMember.role}
         description={boardMember.description}

--- a/src/scenes/home/team/team.js
+++ b/src/scenes/home/team/team.js
@@ -23,7 +23,7 @@ class Team extends Component {
   render() {
     const team = this.state.members.map(member => (
       <TeamCard
-        key={`${Math.random()} + ${member.name}`}
+        key={`${member.name} + ${member.role}`}
         name={member.name}
         role={member.role}
       />
@@ -31,7 +31,7 @@ class Team extends Component {
 
     const boardMembers = BoardMembers.map(boardMember => (
       <BoardCard
-        key={`${Math.random()} + ${boardMember.name}`}
+        key={`${boardMember.name} + ${boardMember.role}`}
         name={boardMember.name}
         role={boardMember.role}
         description={boardMember.description}

--- a/src/shared/components/boardCard/boardCard.css
+++ b/src/shared/components/boardCard/boardCard.css
@@ -67,6 +67,17 @@
 @media screen and (max-width: 850px) {
   .boardCard {
     max-height: 650px;
+    transition: none;
+  }
+
+  .boardCard:hover,
+  .boardCard:focus {
+    transition: none;
+  }
+  
+  .boardCard:hover .descriptionText,
+  .boardCard:active .descriptionText {
+    transition: none;
   }
 
   .descriptionText {

--- a/src/shared/components/boardCard/boardCard.css
+++ b/src/shared/components/boardCard/boardCard.css
@@ -64,7 +64,7 @@
   padding: 1rem 0 0 0;
 }
 
-@media screen and (max-width: 850px) {
+@media screen and (max-width: 450px) {
   .boardCard {
     max-height: 650px;
     transition: none;

--- a/src/shared/components/boardCard/boardCard.css
+++ b/src/shared/components/boardCard/boardCard.css
@@ -63,3 +63,14 @@
   align-self: left;
   padding: 1rem 0 0 0;
 }
+
+@media screen and (max-width: 850px) {
+  .boardCard {
+    max-height: 650px;
+  }
+
+  .descriptionText {
+    opacity: 1;
+    visibility: visible;
+  }
+}


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Disable boardcard height and opacity style for mobile (viewports less than 850px).

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #829 
