### PR TITLE
fixed typo "proimse" to "promise"

### DIFF
--- a/src/scenes/home/landing/emailSignup/emailSignup.js
+++ b/src/scenes/home/landing/emailSignup/emailSignup.js
@@ -63,7 +63,7 @@ class EmailSignup extends Component {
         headingLines={false}
       >
         <p className={styles.emailSignupText}>
-          Keep up to date with everything Operation Code. We proimse we won&#39;t spam you or sell
+          Keep up to date with everything Operation Code. We promise we won&#39;t spam you or sell
           your information.
         </p>
         <Form className={styles.emailListForm}>


### PR DESCRIPTION
# Description of changes
This PR changes the e-mail language in site footer to have promise spelled correctly.

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #
N/A