### PR TITLE
Teamcards

### DIFF
--- a/src/scenes/home/team/team.js
+++ b/src/scenes/home/team/team.js
@@ -1,29 +1,34 @@
 import React, { Component } from 'react';
-import axios from 'axios';
 import Section from 'shared/components/section/section';
 import QuoteBanner from 'shared/components/quoteBanner/quoteBanner';
-import TeamCard from 'shared/components/teamCard/teamCard';
 import BoardCard from 'shared/components/boardCard/boardCard';
+import TeamCard from 'shared/components/teamCard/teamCard';
 import BoardMembers from './boardMembers';
 import styles from './team.css';
 
+
 class Team extends Component {
   state = {
-    members: [],
+    members: [
+      { name: 'David Molina', role: 'CEO', slack: '@david', email: 'david@operationcode.org' },
+      { name: 'Morgan Larrouy-Smith', role: 'Executive Assistant', slack: '', email: 'morgan@operationcode.org' },
+      { name: 'David Reis', role: 'Acting COO', slack: '@davidr', email: '' },
+      { name: 'Jennifer Weiderman', role: 'CCMO', slack: '@Jenn', email: 'jennifer@operationcode.org' },
+      { name: 'Amy Tan', role: 'CFO', slack: '@amy', email: 'amy@operationcode.org' },
+      { name: 'Nell Shamrell', role: 'CTO', slack: '@nellshamrell', email: 'nell@operationcode.org' },
+      { name: 'Kate Horner', role: 'Acting CDO', slack: '@katehorner', email: '' },
+      { name: 'Kelly MacLeod', role: 'HR', slack: '@kelly', email: 'kelly@operationcode.org' },
+      { name: 'Jameel Martin', role: 'Public Policy Director', slack: '@0311-code', email: 'jameel@operationcode.org' },
+      { name: 'Stefano DAniello', role: 'General Counsel', slack: '@stefano', email: '' }
+    ],
   };
-
-  componentDidMount() {
-    axios
-      .get('https://api.operationcode.org/api/v1/team_members.json')
-      .then((response) => {
-        this.setState({ members: response.data });
-      });
-  }
 
   render() {
     const team = this.state.members.map(member => (
       <TeamCard
         key={`${Math.random()} + ${member.name}`}
+        slack={member.slack}
+        email={member.email}
         name={member.name}
         role={member.role}
       />
@@ -59,7 +64,6 @@ class Team extends Component {
             </p>
           </div>
         </Section>
-
         <Section title="Our Team" theme="white">
           <p>
             Our all volunteer staff are dedicated individuals who come from a

--- a/src/scenes/home/team/team.js
+++ b/src/scenes/home/team/team.js
@@ -64,7 +64,7 @@ class Team extends Component {
             </p>
           </div>
         </Section>
-        <Section title="Our Executive Team" theme="white">
+        <Section title="Our Executive Staff" theme="white">
           <p>
             Our all volunteer staff are dedicated individuals who come from a
             wide variety of backgrounds, including members of both the civilian

--- a/src/scenes/home/team/team.js
+++ b/src/scenes/home/team/team.js
@@ -27,10 +27,10 @@ class Team extends Component {
     const team = this.state.members.map(member => (
       <TeamCard
         key={`${Math.random()} + ${member.name}`}
-        slack={member.slack}
-        email={member.email}
         name={member.name}
         role={member.role}
+        email={member.email}
+        slack={member.slack}
       />
     ));
 

--- a/src/scenes/home/team/team.js
+++ b/src/scenes/home/team/team.js
@@ -64,7 +64,7 @@ class Team extends Component {
             </p>
           </div>
         </Section>
-        <Section title="Our Team" theme="white">
+        <Section title="Our Executive Team" theme="white">
           <p>
             Our all volunteer staff are dedicated individuals who come from a
             wide variety of backgrounds, including members of both the civilian

--- a/src/shared/components/teamCard/teamCard.css
+++ b/src/shared/components/teamCard/teamCard.css
@@ -1,3 +1,8 @@
+ul {
+  list-style-type:none;
+  text-align: center;
+}
+
 .teamCard {
   border-radius: 4px;
   align-items: center;
@@ -5,7 +10,8 @@
   margin: 20px 10px;
   /*Width and height affect Lincoln Photo*/
   padding: 10px;
-  width: 185px;
+  /*width: 185px;*/
+  width: 250px;
   height: 110px;
   background: #F0F2F2;
   box-shadow: 0 3px 6px 1px rgba(0, 0, 0, 0.1);

--- a/src/shared/components/teamCard/teamCard.css
+++ b/src/shared/components/teamCard/teamCard.css
@@ -1,16 +1,9 @@
-ul {
-  list-style-type:none;
-  text-align: center;
-}
-
 .teamCard {
   border-radius: 4px;
   align-items: center;
   text-align: center;
-  margin: 20px 10px;
-  /*Width and height affect Lincoln Photo*/
+  margin: 20px 10px;o*/
   padding: 10px;
-  /*width: 185px;*/
   width: 250px;
   height: 110px;
   background: #F0F2F2;

--- a/src/shared/components/teamCard/teamCard.css
+++ b/src/shared/components/teamCard/teamCard.css
@@ -3,6 +3,7 @@
   align-items: center;
   text-align: center;
   margin: 20px 10px;
+  /*Width and height affect Lincoln Photo*/
   padding: 10px;
   width: 185px;
   height: 110px;
@@ -15,12 +16,21 @@
   box-shadow: 0 9px 28px rgba(0,0,0,0.25);
 }
 
+
 .name {
   text-transform: uppercase;
   font-weight: 800;
 }
 
 .role {
+  font-size: .8rem;
+}
+
+.slack {
+  font-size: .8rem;
+}
+
+.email {
   font-size: .8rem;
 }
 

--- a/src/shared/components/teamCard/teamCard.js
+++ b/src/shared/components/teamCard/teamCard.js
@@ -8,11 +8,9 @@ const TeamCard = ({ name, role, email, slack }) => (
       {name}
     </span>
     <hr />
-    <ul>
-      <li className={styles.role}>{role}</li>
-      <li className={styles.slack}>{slack}</li>
-      <li className={styles.email}>{email}</li>
-    </ul>
+    <div className={styles.role}>{role}</div>
+    <div className={styles.slack}>{slack}</div>
+    <div className={styles.email}>{email}</div>
   </div>
 );
 

--- a/src/shared/components/teamCard/teamCard.js
+++ b/src/shared/components/teamCard/teamCard.js
@@ -8,15 +8,11 @@ const TeamCard = ({ name, role, email, slack }) => (
       {name}
     </span>
     <hr />
-    <span className={styles.role}>
-      {role}
-    </span>
-    <span className={styles.email}>
-      {email}
-    </span>
-    <span className={styles.slack}>
-      {slack}
-    </span>
+    <ul>
+      <li className={styles.role}>{role}</li>
+      <li className={styles.slack}>{slack}</li>
+      <li className={styles.email}>{email}</li>
+    </ul>
   </div>
 );
 

--- a/src/shared/components/teamCard/teamCard.js
+++ b/src/shared/components/teamCard/teamCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './teamCard.css';
 
-const TeamCard = ({ name, role }) => (
+const TeamCard = ({ name, role, email, slack }) => (
   <div className={styles.teamCard}>
     <span className={styles.name}>
       {name}
@@ -11,12 +11,20 @@ const TeamCard = ({ name, role }) => (
     <span className={styles.role}>
       {role}
     </span>
+    <span className={styles.email}>
+      {email}
+    </span>
+    <span className={styles.slack}>
+      {slack}
+    </span>
   </div>
 );
 
 TeamCard.propTypes = {
   name: PropTypes.string.isRequired,
-  role: PropTypes.string.isRequired
+  role: PropTypes.string.isRequired,
+  email: PropTypes.string.isRequired,
+  slack: PropTypes.string.isRequired
 };
 
 export default TeamCard;


### PR DESCRIPTION
# Description of changes
The page has been reformatted with "Our Executive Staff" followed by reformats. Individual Team Cards now contain Name,Role,Email, and Slack ID.

# Issue Resolved
I address this issue: https://github.com/OperationCode/operationcode_frontend/issues/825
The Following files were modified:
/shared/teamCard/
     /teamCard.css
     /teamCard.js
/scenes/home/team
     /teams.css
     /teams.js

Recommendations: Immediately open new issue for resizing of Lincoln Photo/Header, possible refactor of all file teams from team to executiveTeam. 