### PR TITLE
validates for empty string or nothing instead of us zip code

### DIFF
--- a/src/shared/components/form/formZipCode/formZipCode.js
+++ b/src/shared/components/form/formZipCode/formZipCode.js
@@ -1,13 +1,17 @@
 import React, { Component } from 'react';
 import FormInput from '../formInput/formInput';
 
+function zipCodeValidator(input) {
+  return (input.length !== 0 && input.trim().length !== 0);
+}
+
 class FormZipCode extends Component {
   render() {
     return (
       <FormInput
         {...this.props}
-        validationRegex={/(^\d{5}$)|(^\d{5}-\d{4}$)/}
-        validationErrorMessage="Must be a valid US zip code"
+        validateFunc={zipCodeValidator}
+        validationErrorMessage="Must enter a valid zip code"
         ref={(child) => { this.inputRef = child; }}
       />
     );


### PR DESCRIPTION
# Description of changes
Removes US specific zipcode validation and simply validates form input isn't whitespace or absent. This validation was moved to the back and relies on geocoder to make sure its a valid zipcode.

# Issue Resolved
Fixes 244 on operationcode_backend
