### PR TITLE
Feature/844 clarify get verified

### DIFF
--- a/src/scenes/home/profile/profile.css
+++ b/src/scenes/home/profile/profile.css
@@ -52,6 +52,11 @@
   font-size: 1.5rem;
 }
 
+.profileContainer__verified__services {
+  font-weight: bold;
+  color:#249CBC;
+}
+
 @media screen and (max-width: 1000px) {
   .profileContainer {
     flex-direction: column;

--- a/src/scenes/home/profile/profile.js
+++ b/src/scenes/home/profile/profile.js
@@ -56,10 +56,12 @@ const Profile = ({ verified }) => (
               Get Verified for Added Benefits
             </span>
             <p>
-              In order to take advantage of resources such as Mentorship and Scholarships, we
-              require that you verify your military affiliation status. We use Id.Me for
-              verification, a highly secure and specialized platform that will protect your
-              information. We will not store or transfer any of your sensitive information.
+              To gain access to <span className={styles.profileContainer__verified__services}>Mentorship</span> and <span className={styles.profileContainer__verified__services}>Scholarships</span>, we
+              require that you verify your military status.
+            </p>
+
+            <p>
+              Sign in below to get verified!
             </p>
             <Idme />
           </div>


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->

When on the profile page, it is hard to discern that we offer Mentorship and Scholarship services, unless you really read through the "Get Verified for Added Benefits" paragraph closely.

This PR makes the following changes to the "Get Verified for Added Benefits" section:
- makes it more clear that Mentorship and Scholarship are services that we offer
- makes the content less dense, and more readable, when glancing or skimming
- aligns the content in the description more closely with the ID.me call to action button 

## Before

![image](https://user-images.githubusercontent.com/7482329/35782748-1610f874-09ba-11e8-9c2a-3e4d2e4ba7e5.png)

## After

![image](https://user-images.githubusercontent.com/7482329/35782752-1feeaf3a-09ba-11e8-8b60-ac36a0769243.png)

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #844 
