### PR TITLE
Update broken link to EPS file on branding page (fixes #858)

### DIFF
--- a/src/scenes/home/branding/logos/logos.js
+++ b/src/scenes/home/branding/logos/logos.js
@@ -37,7 +37,7 @@ const LogosSection = () => (
       delivered for special uses only.
     </p>
     <p className={styles.logosInfo}>
-      <a href="https://ocbranding.squarespace.com/s/Operation-Code-Logo.eps">
+      <a href="https://s3.us-east-2.amazonaws.com/operationcode-web/Operation-Code-Logo.eps">
         Download master EPS file
       </a>
     </p>


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Updates the broken link on https://operationcode.org/branding for the downloadable EPS file, pointing to the asset which is now located on AWS S3: https://s3.us-east-2.amazonaws.com/operationcode-web/Operation-Code-Logo.eps 

As part of this PR I created the S3 bucket named 'operationcode-web' (the name 'operationcode' was taken), with default settings, in region US-East (Ohio).  So far, this is the only S3 bucket we're using, with only the EPS file uploaded.   If we want to further configure S3 setup we can address that in #866.
# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #858 
