### PR TITLE
Issue #887 - Adjust layout for team cards at mobile-screen sizes

### DIFF
--- a/src/scenes/home/team/team.css
+++ b/src/scenes/home/team/team.css
@@ -8,9 +8,9 @@
 .executiveStaff {
   align-items: flex-start;
   display: flex;
-  flex-wrap: wrap;
-  padding: 20px 0;
+  flex-flow: row wrap;
   justify-content: space-between;
+  padding: 20px 0;
 }
 
 .foundingMembers {
@@ -18,9 +18,11 @@
 }
 
 @media screen and (max-width: 840px) {
-  .boardMembers {
+  .boardMembers,
+  .executiveStaff {
     align-items: center;
-    flex-flow: column nowrap;
+    flex-direction: column;
     justify-content: space-between;
+    width: 100%;
   }
 }

--- a/src/shared/components/teamCard/teamCard.css
+++ b/src/shared/components/teamCard/teamCard.css
@@ -75,8 +75,8 @@
   padding: 1rem 0 0 0;
 }
 
-@media screen and (max-width: 440px) {
+@media screen and (max-width: 840px) {
   .teamCard {
-    width: 100px;
+    width: 80%;
   }
 }


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Adjusts the CSS for the Team page at /team and the TeamCard components so they resize to a one-column layout at screen-widths of 840px or less.  The cards will be a bit wider on mobile-size screens, but this should also prevent text from overflowing out of the cards.

# Screenshots (after changes):
![selection_015](https://user-images.githubusercontent.com/8835055/37015100-ce329ac8-20d2-11e8-90f6-f10db8420c2b.png)
![selection_016](https://user-images.githubusercontent.com/8835055/37015105-d1f307ec-20d2-11e8-9e74-9894f86ee490.png)

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #887 
