### PR TITLE
remove 'Request Help' nav item

### DIFF
--- a/src/scenes/home/header/header.js
+++ b/src/scenes/home/header/header.js
@@ -30,7 +30,6 @@ class Header extends Component {
         <NavItem to="/jobs" text="Job Board" onClick={onClick} />
         <NavItem to="https://opencollective.com/operationcode#support" text="Donate" onClick={onClick} isExternal />
         <NavItem to="/leadership_circle" text="Leadership Circle" onClick={onClick} />
-        {signedIn && <NavItem to="https://op.co.de/mentor-request" text="Request Help" onClick={onClick} isExternal />}
         {signedIn ? <NavItem to="/profile" text="Profile" onClick={onClick} />
           : <NavItem to="/join" text="Join" onClick={onClick} />}
         {signedIn ? <NavItem to="/" text="Logout" onClick={this.props.logOut} />


### PR DESCRIPTION
# Description of changes
Remove the 'Request Help' link from the nav, so it doesn't appear in the top-aligned nav bar (desktop) or the side-aligned nav drawer (mobile).

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #891 
