### PR TITLE
Fix usage of IconCard on contacts page

### DIFF
--- a/src/scenes/home/contact/contact.css
+++ b/src/scenes/home/contact/contact.css
@@ -25,17 +25,3 @@ a:hover > svg {
 .centerText {
   text-align: center;
 }
-
-/* Icons are not uniform in size... */
-.slackIcon {
-  padding: 27.5px 0 18.5px 0;
-}
-
-.mailIcon {
-  padding: 0 0 16px 0;
-}
-
-.address {
-  text-align: left;
-  padding: 0 0 0 27px;
-}

--- a/src/scenes/home/contact/contact.js
+++ b/src/scenes/home/contact/contact.js
@@ -26,7 +26,7 @@ const Contact = () => (
         />
         <IconCard
           title="Slack Team"
-          fontAwesomeIcon="faSlack"
+          fontAwesomeIcon="faSlackHash"
           iconType="brand"
           iconSize="6x"
           url="https://operation-code.slack.com"

--- a/src/scenes/home/contact/contact.js
+++ b/src/scenes/home/contact/contact.js
@@ -18,15 +18,24 @@ const Contact = () => (
       <div className={styles.flexContainer}>
         {/* Columns */}
         <IconCard
-          title="Email" fontAwesomeIcon="FaEnvelope" iconSize={175} url="mailto:staff@operationcode.org"
+          title="Email"
+          fontAwesomeIcon="faEnvelope"
+          iconSize="6x"
+          url="mailto:staff@operationcode.org"
           subText="staff@operationcode.org"
         />
         <IconCard
-          title="Slack Team" fontAwesomeIcon="FaSlack" iconSize={175} url="https://operation-code.slack.com"
+          title="Slack Team"
+          fontAwesomeIcon="faSlack"
+          iconType="brand"
+          iconSize="6x"
+          url="https://operation-code.slack.com"
           subText="https://operation-code.slack.com"
         />
         <IconCard
-          title="Mailing Address" fontAwesomeIcon="FaHome" iconSize={175}
+          title="Mailing Address"
+          fontAwesomeIcon="faHome"
+          iconSize="6x"
           subText="Operation Code<br/>
             707 SW Washington St.<br/>
             Suite 1100<br/>

--- a/src/shared/components/iconCard/iconCard.css
+++ b/src/shared/components/iconCard/iconCard.css
@@ -1,7 +1,6 @@
 .iconCard {
   padding: 10px;
   width: 180px;
-  height: 180px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -17,10 +16,6 @@ a.iconCard {
 
 a.iconCard:hover {
   color: #444;
-}
-
-.iconCardWithSubText {
-  min-height: 350px;
 }
 
 .iconCard__icon {


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Fixes usage of IconCards on contacts page so the font-awesome icons display. With the changes introduced in #872, the `fontAwesomeIcon` prop that is passed to the IconCard component needs to be in camelCase, not PascalCase.  

Also note that the correct `iconType` prop needs to be passed in to IconCard if the icon is in the 'fontawesome-free-brands' or 'fontawesome-free-regular' NPM package - defaulting to 'fontawesome-free-solid' if no prop passed in. (see [iconCard.js](https://github.com/OperationCode/operationcode_frontend/blob/master/src/shared/components/iconCard/iconCard.js))  

My fault on this one, I overlooked this page when I submitted for #872 .

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #901 

# Screenshot:

![selection_024](https://user-images.githubusercontent.com/8835055/37249125-17f8141e-24af-11e8-86fc-3ac967c5c7dc.png)
