### PR TITLE
Fix mobile about page banner text overflow

### DIFF
--- a/src/scenes/home/about/about.css
+++ b/src/scenes/home/about/about.css
@@ -35,6 +35,11 @@
 }
 
 @media screen and (max-width: 465px) {
+  .banner {
+    height: auto;
+    padding: 30px 0;
+  }
+
   .serviceSeal {
     height: 75px;
     width: 75px;


### PR DESCRIPTION
# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #903



# Screenshot:
I've tested this on my Android phone, looks good. If anyone has an iPhone, please test dev server on an actual device - looks good on Chrome DevTools so far:

![selection_025](https://user-images.githubusercontent.com/8835055/37249306-1c7da284-24b3-11e8-8001-f48cbb36022c.png)

