### PR TITLE
Remove policy banner from landing page

### DIFF
--- a/src/scenes/home/landing/hero/hero.css
+++ b/src/scenes/home/landing/hero/hero.css
@@ -1,6 +1,7 @@
 .container {
   display: flex;
   flex-flow: column;
+  padding-top: 20px;
 }
 
 .header {

--- a/src/scenes/home/landing/landing.js
+++ b/src/scenes/home/landing/landing.js
@@ -11,7 +11,6 @@ import Partners from './partners/partners';
 import Donate from '../../../shared/components/donate/donate';
 import Join from '../../../shared/components/join/join';
 import TopCode from './topcodeBanner/topcodeBanner';
-import PolicyBanner from '../policy/policyBanner';
 import EmailSignup from './emailSignup/emailSignup';
 
 import styles from './landing.css';
@@ -51,7 +50,6 @@ class Landing extends Component {
             <p>Content</p>
           </div>
         </ReactModal>
-        <PolicyBanner />
         <Hero />
         <TopCode />
         <Membership />

--- a/src/scenes/home/policy/policy.js
+++ b/src/scenes/home/policy/policy.js
@@ -1,15 +1,15 @@
 import React from 'react';
-import OutboundLink from 'shared/components/outboundLink/outboundLink';
 import styles from './policy.css';
 
-const formLink = 'https://goo.gl/forms/kJUhtxHConEVKpy23';
+// replace commented out info div below with new event info content if
+// this component is needed for reuse in the future
 
 const Policy = () => (
   <div className={styles.content}>
     <h1 className={styles.header}>
       <div className={styles.title}>Modernize the GI Bill</div>
       <div className={styles.subtitle}>
-        We&apos;re heading to Washington, D.C. to demand that Congress develop
+        Demand that Congress develop
         policies to make veterans more competitive for careers in the tech
         sector.
       </div>
@@ -31,7 +31,7 @@ const Policy = () => (
       </figure>
     </div>
 
-    <div className={styles.info}>
+    {/* <div className={styles.info}>
       <h1 className={styles.infoSubtitle}>
         Join us on our mission to spread awareness, demand change, and seek
         solutions.
@@ -50,7 +50,7 @@ const Policy = () => (
           RSVP
         </OutboundLink>
       </div>
-    </div>
+    </div> */}
   </div>
 );
 

--- a/src/scenes/home/policy/policyBanner.js
+++ b/src/scenes/home/policy/policyBanner.js
@@ -3,10 +3,12 @@ import styles from './policyBanner.css';
 
 const policyPageLink = '/policy';
 
+// replace commented out bannertext below with new text if this component is needed for reuse in the future
+
 const PolicyBanner = () => (
   <div className={styles.banner}>
     <h4 className={styles.bannerText}>
-      On April 19, 2018, we&apos;re heading to Washington, D.C. to modernize the G.I. Bill.{' '}
+      {/* On April 19, 2018, we&apos;re heading to Washington, D.C. to modernize the G.I. Bill.{' '} */}
       <a href={policyPageLink} className={styles.bannerLink}>
         Click here for details!
       </a>


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
* Removes `PolicyBanner` component from landing page (April 19 event has already happened)
* Leaves `PolicyBanner` component in codebase, with April 19 event details commented out.  Can be reused for another policy event in the future with new text if necessary.
* `Policy` component (policy page): Commented out event info and RSVP link from policy page (April 19 event has already happened).  Event / RSVP markup can be reused for another policy event in the future with new text if necessary.
# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #949
