### PR TITLE
Update /team page to reflect new organizational structure

### DIFF
--- a/src/scenes/home/team/team.js
+++ b/src/scenes/home/team/team.js
@@ -66,9 +66,11 @@ class Team extends Component {
             <p>
               Operation Code deeply appreciates the time, energy, and hard work
               of our <b>Founding Board Members</b>, including Mark Kerr (Chair),
-              Laura Gomez (Vice Chair), Pete Runyon (Secretary/ Treasurer), Josh
-              Carter, Nick Frost, and Aimee Knight on their support, dedication
-              and commitment in the early days.
+              Laura Gomez (Vice Chair), Dr. Tyrone Grandison (Vice Chair), Dr. Stacy
+              Chin (Director of Fundraising Committee), Liza Rodewald (Director of
+              Military Families Committee), Pete Runyon (Secretary/ Treasurer), Josh
+              Carter, Nick Frost, and Aimee Knight on their support, dedication and
+              commitment in the early days.
             </p>
 
             <p style={{ textAlign: 'center' }}>

--- a/src/scenes/home/team/team.js
+++ b/src/scenes/home/team/team.js
@@ -23,12 +23,18 @@ class Team extends Component {
         const sortById = members => members.sort((a, b) => a.id - b.id);
         const sortedMembers = sortById(response.data);
 
-        const boardMembers = sortedMembers.filter(x => x.group === 'board');
+        let boardMembers = sortedMembers.filter(x => x.group === 'board');
         let executiveStaffMembers = sortedMembers.filter(x => x.group === 'team');
 
-        // add founder as first member of executive staff, even though he's in group 'board'
-        const founder = boardMembers.filter(x => x.name === 'David Molina');
-        executiveStaffMembers = [...founder, ...executiveStaffMembers];
+        // reorder board members so board chair is first
+        const isBoardChair = boardMember => boardMember.name === 'David Molina';
+        const boardChair = boardMembers.filter(x => isBoardChair(x));
+        const nonChairBoardMembers = boardMembers.filter(x => !isBoardChair(x));
+        boardMembers = [...boardChair, ...nonChairBoardMembers];
+
+        // add CEO as first member of executive staff, even though he's in group 'board'
+        const CEO = boardMembers.filter(x => x.name === 'Conrad Hollomon');
+        executiveStaffMembers = [...CEO, ...executiveStaffMembers];
 
         this.setState({ boardMembers, executiveStaffMembers });
       })


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
 * Add three former board members to the 'Founding Board Members' list:  Dr. Tyrone Grandison, Dr. Stacy Chin, Liza Rodewald
 * Conrad Hollomon's team card now displays in both the Board and Executive Staff groups
  * David Molina's team card now only displays on the Board group
  * Since David Molina is now Board Chairman, the Board group team cards should be sorted so his card displays first (before the Vice Chairman)
# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #975
