### PR TITLE
Display featured jobs on Jobs page, above search results

### DIFF
--- a/src/scenes/home/jobs/featuredJob/featuredJob.css
+++ b/src/scenes/home/jobs/featuredJob/featuredJob.css
@@ -1,2 +1,43 @@
-/* Note: these styles are copied to match the ziprecruiter styles that are inserted on our page */
+/* Note: these styles are copied to match the ziprecruiter styles that are being dynamically inserted on our page (see jobs.js) */
 
+.job {
+  padding: 15px 0px;
+}
+
+.link {
+  text-decoration: none;
+  color: #1a0dab;
+  font-size: 17px;
+  float: left;
+  margin-right: 3px;
+  margin-bottom: 1px;
+}
+
+.details {
+  font-size: 13px;
+  color: #999999;
+  margin: 3px 0;
+  clear: both;
+}
+
+.detailsContainer {
+  float: left;
+  margin-right: 15px;
+}
+
+.detail {
+  margin-left: 4px;
+}
+
+.remote {
+  composes: detail;
+  font-style: italic;
+}
+
+.description {
+  clear: both;
+  font-size: 14px;
+  color: #545454;
+  line-height: 1.4;
+  word-wrap: break-word;
+}

--- a/src/scenes/home/jobs/featuredJob/featuredJob.css
+++ b/src/scenes/home/jobs/featuredJob/featuredJob.css
@@ -1,0 +1,2 @@
+/* Note: these styles are copied to match the ziprecruiter styles that are inserted on our page */
+

--- a/src/scenes/home/jobs/featuredJob/featuredJob.js
+++ b/src/scenes/home/jobs/featuredJob/featuredJob.js
@@ -29,9 +29,9 @@ const FeaturedJob = ({
         </div>
         <div className={styles.detailsContainer}>
           <FontAwesomeIcon icon={faMapMarkerAlt} size="sm" style={{ color: '#afafaf' }} />
-          <span className={styles.detail}>{city},</span>
-          <span className={styles.detail}>{state},</span>
-          <span className={styles.detail}>{country}</span>
+          {city && <span className={styles.detail}>{city},</span>}
+          {state && <span className={styles.detail}>{state},</span>}
+          {country && <span className={styles.detail}>{country}</span>}
         </div>
         {remote &&
           <div className={styles.detailsContainer}>

--- a/src/scenes/home/jobs/featuredJob/featuredJob.js
+++ b/src/scenes/home/jobs/featuredJob/featuredJob.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { faMapMarkerAlt, faBuilding, faCloudUploadAlt } from '@fortawesome/fontawesome-free-solid';
+import OutboundLink from 'shared/components/outboundLink/outboundLink';
 import styles from './featuredJob.css';
 
 const FeaturedJob = ({
@@ -17,7 +18,9 @@ const FeaturedJob = ({
   <div>
     <div className={styles.job}>
       <div>
-        <a rel="nofollow" href={sourceUrl} className="zr_job_link">{title}</a>
+        <OutboundLink href={sourceUrl} analyticsEventLabel={`[FeaturedJob] ${sourceUrl}`}>
+          <span className={styles.link}>{title}</span>
+        </OutboundLink>
       </div>
       <div className={styles.details}>
         <div className={styles.detailsContainer}>

--- a/src/scenes/home/jobs/featuredJob/featuredJob.js
+++ b/src/scenes/home/jobs/featuredJob/featuredJob.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faMapMarkerAlt, faBuilding, faCloudUploadAlt } from '@fortawesome/fontawesome-free-solid';
+import styles from './featuredJob.css';
 
 const FeaturedJob = ({
   title,
@@ -12,23 +15,33 @@ const FeaturedJob = ({
   remote
 }) => (
   <div>
-    <div className="zr_job">
-      <div className="zr_job_title">
+    <div className={styles.job}>
+      <div>
         <a rel="nofollow" href={sourceUrl} className="zr_job_link">{title}</a>
       </div>
-      <div className="zr_job_details">
-        <div className="zr_job_detail_container">
-          <span className="zr_job_company">{source}</span>
-          <span className="zr_job_city">{city}</span>
-          <span className="zr_job_state">{state}</span>
-          <span className="zr_job_country">{country}</span>
-          <span className="zr_job_remote">{remote ? 'Remote' : ''}</span>
+      <div className={styles.details}>
+        <div className={styles.detailsContainer}>
+          <FontAwesomeIcon icon={faBuilding} size="sm" style={{ color: '#afafaf' }} />
+          <span className={styles.detail}>{source}</span>
         </div>
-        <div className="zr_job_detail_container" />
+        <div className={styles.detailsContainer}>
+          <FontAwesomeIcon icon={faMapMarkerAlt} size="sm" style={{ color: '#afafaf' }} />
+          <span className={styles.detail}>{city},</span>
+          <span className={styles.detail}>{state},</span>
+          <span className={styles.detail}>{country}</span>
+        </div>
+        {remote &&
+          <div className={styles.detailsContainer}>
+            <FontAwesomeIcon icon={faCloudUploadAlt} size="sm" style={{ color: '#afafaf' }} />
+            <span className={styles.remote}>Remote</span>
+          </div>
+        }
       </div>
-      <div className="zr_job_desc">{description}</div>
+      <div className={styles.description}>
+        {description}
+      </div>
     </div>
-  </div>
+  </div >
 );
 
 FeaturedJob.propTypes = {

--- a/src/scenes/home/jobs/featuredJob/featuredJob.js
+++ b/src/scenes/home/jobs/featuredJob/featuredJob.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const FeaturedJob = ({
+  title,
+  source,
+  sourceUrl,
+  city,
+  state,
+  country,
+  description,
+  remote
+}) => (
+  <div>
+    <div className="zr_job">
+      <div className="zr_job_title">
+        <a rel="nofollow" href={sourceUrl} className="zr_job_link">{title}</a>
+      </div>
+      <div className="zr_job_details">
+        <div className="zr_job_detail_container">
+          <span className="zr_job_company">{source}</span>
+          <span className="zr_job_city">{city}</span>
+          <span className="zr_job_state">{state}</span>
+          <span className="zr_job_country">{country}</span>
+          <span className="zr_job_remote">{remote ? 'Remote' : ''}</span>
+        </div>
+        <div className="zr_job_detail_container" />
+      </div>
+      <div className="zr_job_desc">{description}</div>
+    </div>
+  </div>
+);
+
+FeaturedJob.propTypes = {
+  title: PropTypes.string.isRequired,
+  source: PropTypes.string.isRequired,
+  sourceUrl: PropTypes.string.isRequired,
+  city: PropTypes.string.isRequired,
+  state: PropTypes.string.isRequired,
+  country: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  remote: PropTypes.bool
+};
+
+FeaturedJob.defaultProps = {
+  remote: false
+};
+
+export default FeaturedJob;

--- a/src/scenes/home/jobs/featuredJobs.json
+++ b/src/scenes/home/jobs/featuredJobs.json
@@ -1,13 +1,13 @@
 [
   {
-    "title": "Software Engineer",
+    "title": "Software Engineer (Mock Data)",
     "source": "Microsoft",
     "sourceUrl": "https://www.microsoft.com",
     "city": "Redmond",
     "state": "Washington",
     "country": "United States",
     "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-    "status": "active",
+    "status": "inactive",
     "remote": false,
     "tags": [
       "C#",
@@ -16,14 +16,14 @@
     ]
   },
   {
-    "title": "QA Engineer",
+    "title": "QA Engineer (Mock Data)",
     "source": "Apple",
     "sourceUrl": "https://www.apple.com",
     "city": "San Francisco",
     "state": "California",
     "country": "United States",
     "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ",
-    "status": "active",
+    "status": "inactive",
     "remote": true,
     "tags": [
       "C#",
@@ -32,11 +32,11 @@
     ]
   },
   {
-    "title": "DevOps Engineeer",
+    "title": "DevOps Engineeer (Mock Data)",
     "source": "GitHub",
     "sourceUrl": "https://www.github.com",
     "city": "Austin",
-    "state": "texas",
+    "state": "Texas",
     "country": "United States",
     "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
     "status": "inactive",

--- a/src/scenes/home/jobs/featuredJobs.json
+++ b/src/scenes/home/jobs/featuredJobs.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "Software Engineeer",
+    "title": "Software Engineer",
     "source": "Microsoft",
     "sourceUrl": "https://www.microsoft.com",
     "city": "Redmond",
@@ -16,7 +16,7 @@
     ]
   },
   {
-    "title": "QA Engineeer",
+    "title": "QA Engineer",
     "source": "Apple",
     "sourceUrl": "https://www.apple.com",
     "city": "San Francisco",
@@ -24,7 +24,7 @@
     "country": "United States",
     "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ",
     "status": "active",
-    "remote": false,
+    "remote": true,
     "tags": [
       "C#",
       "ASP.Net",

--- a/src/scenes/home/jobs/featuredJobs.json
+++ b/src/scenes/home/jobs/featuredJobs.json
@@ -1,50 +1,47 @@
 [
   {
-    "title": "Software Engineer (Mock Data)",
-    "source": "Microsoft",
-    "sourceUrl": "https://www.microsoft.com",
-    "city": "Redmond",
-    "state": "Washington",
-    "country": "United States",
-    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-    "status": "inactive",
-    "remote": false,
-    "tags": [
-      "C#",
-      "ASP.Net",
-      "DevOps"
-    ]
-  },
-  {
-    "title": "QA Engineer (Mock Data)",
-    "source": "Apple",
-    "sourceUrl": "https://www.apple.com",
-    "city": "San Francisco",
-    "state": "California",
-    "country": "United States",
-    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ",
-    "status": "inactive",
+    "title": "Technical Product Marketing Manager",
+    "source": "GitLab",
+    "sourceUrl": "https://jobs.lever.co/gitlab/022890d6-549a-48fe-8891-51c13b8d1137",
+    "city": "",
+    "state": "",
+    "country": "Any",
+    "description": "As a Technical Product Marketing Manager, you will work closely with our marketing, engineering, business development and sales team, and partners to help them understand how core GitLab technical value offerings solve customer problems as well as educate them about market competitors.  You will be responsible for technical marketing content and representing GitLab as a technical evangelist at key trade shows and customer meetings.",
+    "status": "active",
     "remote": true,
     "tags": [
-      "C#",
-      "ASP.Net",
-      "DevOps"
+      "Marketing",
+      "Product Management"
     ]
   },
   {
-    "title": "DevOps Engineeer (Mock Data)",
-    "source": "GitHub",
-    "sourceUrl": "https://www.github.com",
-    "city": "Austin",
-    "state": "Texas",
-    "country": "United States",
-    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-    "status": "inactive",
-    "remote": false,
+    "title": "Senior Database Engineer",
+    "source": "GitLab",
+    "sourceUrl": "https://jobs.lever.co/gitlab/8b711f1c-d378-4383-a027-bac550aeee6d",
+    "city": "",
+    "state": "",
+    "country": "Americas",
+    "description": "Our database engineer is a hybrid role: part developer, part database expert. You will spend the majority of your time making application changes to improve database performance, availability, and reliability; though you will also spend time working on the database infrastructure that powers GitLab.com. Infrastructure work involves (but is not limited to) tasks such as making configuration changes, adjusting monitoring, and upgrading the database.",
+    "status": "active",
+    "remote": true,
     "tags": [
-      "C#",
-      "ASP.Net",
-      "DevOps"
+      "Infrastructure",
+      "Database"
+    ]
+  },
+  {
+    "title": "Field Marketing Manager",
+    "source": "GitLab",
+    "sourceUrl": "https://jobs.lever.co/gitlab/f53275a2-bac6-43c8-9a7f-a1d3021c9521",
+    "city": "",
+    "state": "",
+    "country": "Asia Pacific",
+    "description": "GitLab is looking for a highly motivated, sales-focused field marketer who will be responsible for supporting our Asia Pacific (APAC) sales team. A successful Field Marketing Manager has strong understanding of sales-focused marketing as well as our audiences of enterprise IT leaders, IT ops practitioners, and developers. They enjoy taking charge of regional marketing programs, detailed planning, proactive communication, and flawlessly delivering memorable marketing experiences supporting our sales objectives.",
+    "status": "active",
+    "remote": true,
+    "tags": [
+      "Marketing",
+      "Sales"
     ]
   }
 ]

--- a/src/scenes/home/jobs/featuredJobs.json
+++ b/src/scenes/home/jobs/featuredJobs.json
@@ -1,0 +1,50 @@
+[
+  {
+    "title": "Software Engineeer",
+    "source": "Microsoft",
+    "sourceUrl": "https://www.microsoft.com",
+    "city": "Redmond",
+    "state": "Washington",
+    "country": "United States",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+    "status": "active",
+    "remote": false,
+    "tags": [
+      "C#",
+      "ASP.Net",
+      "DevOps"
+    ]
+  },
+  {
+    "title": "QA Engineeer",
+    "source": "Apple",
+    "sourceUrl": "https://www.apple.com",
+    "city": "San Francisco",
+    "state": "California",
+    "country": "United States",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ",
+    "status": "active",
+    "remote": false,
+    "tags": [
+      "C#",
+      "ASP.Net",
+      "DevOps"
+    ]
+  },
+  {
+    "title": "DevOps Engineeer",
+    "source": "GitHub",
+    "sourceUrl": "https://www.github.com",
+    "city": "Austin",
+    "state": "texas",
+    "country": "United States",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+    "status": "inactive",
+    "remote": false,
+    "tags": [
+      "C#",
+      "ASP.Net",
+      "DevOps"
+    ]
+  }
+]

--- a/src/scenes/home/jobs/jobs.css
+++ b/src/scenes/home/jobs/jobs.css
@@ -12,3 +12,9 @@
   width: 100%;
   max-width: 768px;
 }
+
+.contact {
+    margin: 30px 0 0 0;
+    align-self: flex-start;
+    font-size: 1rem;
+}

--- a/src/scenes/home/jobs/jobs.css
+++ b/src/scenes/home/jobs/jobs.css
@@ -1,0 +1,14 @@
+/* Note: these styles are copied to match the ziprecruiter styles that are inserted on our page */
+
+.featuredJobsContainer {
+  width: 100%;
+  float: left;
+  clear: both;
+}
+
+.featuredJobs {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 30px 0px 10px;
+  width: 100%;
+  max-width: 768px;
+}

--- a/src/scenes/home/jobs/jobs.js
+++ b/src/scenes/home/jobs/jobs.js
@@ -36,19 +36,11 @@ class Jobs extends Component {
 
   render() {
     const featuredJobs = FeaturedJobsData
-      .filter(x => x.status === 'active')
+      .filter(job => job.status === 'active')
       .map(job => (
         <FeaturedJob
           key={`${Math.random()} + ${job.name} + ${job.sourceUrl}`}
-          title={job.title}
-          source={job.source}
-          sourceUrl={job.sourceUrl}
-          city={job.city}
-          state={job.state}
-          country={job.country}
-          description={job.description}
-          status={job.status}
-          remote={job.remote}
+          {...job}
         />
       ));
 

--- a/src/scenes/home/jobs/jobs.js
+++ b/src/scenes/home/jobs/jobs.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Section from 'shared/components/section/section';
+import OutboundLink from 'shared/components/outboundLink/outboundLink';
 import FeaturedJob from './featuredJob/featuredJob';
 import FeaturedJobsData from './featuredJobs.json';
 import styles from './jobs.css';
@@ -60,7 +61,7 @@ class Jobs extends Component {
             </div>
           </div>
           <p className={styles.contact}>
-            Are you hiring? <a href="mailto:staff@operationcode.org">Contact</a> us to post your job opening with Operation Code!
+            Are you hiring? <OutboundLink href="mailto:kelly@operationcode.org" analyticsEventLabel="User clicked on Job Posting contact">Contact</OutboundLink> us to post your job opening with Operation Code!
           </p>
         </Section>
         <Section title="Search All Jobs" theme="white">

--- a/src/scenes/home/jobs/jobs.js
+++ b/src/scenes/home/jobs/jobs.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import Section from 'shared/components/section/section';
+import FeaturedJob from './featuredJob/featuredJob';
+import FeaturedJobsData from './featuredJobs.json';
+import styles from './jobs.css';
 
 const zipRecruiterScript = document.createElement('script');
 
@@ -29,11 +32,39 @@ class Jobs extends Component {
     };
     tryRunInit();
   }
+
+  featuredJobs
   render() {
+    const featuredJobs = FeaturedJobsData
+      .filter(x => x.status === 'active')
+      .map(job => (
+        <FeaturedJob
+          key={`${Math.random()} + ${job.name} + ${job.sourceUrl}`}
+          title={job.title}
+          source={job.source}
+          sourceUrl={job.sourceUrl}
+          city={job.city}
+          state={job.state}
+          country={job.country}
+          description={job.description}
+          status={job.status}
+          remote={job.remote}
+        />
+      ));
     return (
-      <Section title="Open Positions" theme="white">
-        <div id="zipsearch_container" />
-      </Section>
+      <div>
+        <Section title="Featured Jobs" theme="white">
+          <div className={styles.featuredJobsContainer}>
+            <div className={styles.featuredJobs}>
+              {featuredJobs}
+            </div>
+          </div>
+        </Section>
+        <Section title="Search All Jobs" theme="white">
+          <div id="zipsearch_container" />
+        </Section>
+      </div>
+
     );
   }
 }

--- a/src/scenes/home/jobs/jobs.js
+++ b/src/scenes/home/jobs/jobs.js
@@ -33,7 +33,6 @@ class Jobs extends Component {
     tryRunInit();
   }
 
-  featuredJobs
   render() {
     const featuredJobs = FeaturedJobsData
       .filter(x => x.status === 'active')
@@ -51,14 +50,18 @@ class Jobs extends Component {
           remote={job.remote}
         />
       ));
+
     return (
       <div>
-        <Section title="Featured Jobs" theme="white">
+        <Section title="Featured Jobs" theme="whiteCondensed">
           <div className={styles.featuredJobsContainer}>
             <div className={styles.featuredJobs}>
               {featuredJobs}
             </div>
           </div>
+          <p className={styles.contact}>
+            Are you hiring? <a href="mailto:staff@operationcode.org">Contact</a> us to post your job opening with Operation Code!
+          </p>
         </Section>
         <Section title="Search All Jobs" theme="white">
           <div id="zipsearch_container" />

--- a/src/shared/components/section/section.css
+++ b/src/shared/components/section/section.css
@@ -15,6 +15,15 @@
   background-color: #FFF;
 }
 
+.condensed {
+  min-height: 0;
+}
+
+.whiteCondensed {
+  composes: white;
+  composes: condensed;
+}
+
 .content {
   display: flex;
   flex-flow: column;


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
Displays 'Featured Jobs' section above Ziprecruiter job search section on /jobs page.

Screenshot w/ mock data:
![selection_057](https://user-images.githubusercontent.com/8835055/40881502-2962a3e4-6696-11e8-9ea2-bbfb7c9479fe.png)

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
MVP requirements for #982 

**Note** - do not merge this yet, as we still need content - the actual 'featured' jobs which will be highlighted at the top of the page. The front-end code is ready for review, I'm currently pulling in data from the static `featuredJobs.json` file, which only contains mock data for now.  This new feature should not go live until we actually have featured jobs to display on the page.  They can be loaded from `featuredJobs.json` or the API & DB (see [Back-end PR # 366](https://github.com/OperationCode/operationcode_backend/pull/366))
