### PR TITLE
Show loading spinner after creating mentor request

### DIFF
--- a/src/scenes/home/mentorRequest/mentorRequest.js
+++ b/src/scenes/home/mentorRequest/mentorRequest.js
@@ -83,11 +83,15 @@ class MentorRequest extends Component {
     .sort((a, b) => a.name.localeCompare(b.name)) // sort alphabetically
     .map(x => ({ value: x.id, label: x.name }))
 
-  handleOnClick = async (event) => {
+  handleOnClick = (event) => {
     event.preventDefault();
 
     if (!this.isValid()) return;
 
+    this.setState({ isLoading: true }, this.createRequest);
+  }
+
+  createRequest = async () => {
     try {
       await ApiHelpers.createMentorRequest({
         slackUser: this.state.slackUserName,
@@ -108,6 +112,8 @@ class MentorRequest extends Component {
       table, which contains exact matches for the predefined skillset options on the Airtable
       Mentor Request table. */
       this.setState({ submitError: 'There was an error requesting a mentor.' });
+    } finally {
+      this.setState({ isLoading: false });
     }
   }
 


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
- Spinner will display (instead of form) while waiting on API response after submit.
- On API response, spinner will disappear and either:
  - the success message will display in place of the form
  - the error message will display below the form (to give the user the opportunity to re-submit it).
# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #1033 
