### PR TITLE
Move imgSources to AWS and add 1Password

### DIFF
--- a/src/scenes/home/landing/partners/partnerRoster.js
+++ b/src/scenes/home/landing/partners/partnerRoster.js
@@ -1,47 +1,42 @@
-import apexLogo from 'images/partnerLogos/apex_systems_logo.png';
-import githubLogo from 'images/partnerLogos/github_logo.png';
-import dockerLogo from 'images/partnerLogos/docker_logo.png';
-import oracleLogo from 'images/partnerLogos/oracle_logo.png';
-import oreillyLogo from 'images/partnerLogos/oreilly_logo.png';
-import hackerrankLogo from 'images/partnerLogos/hackerrank_logo.png';
-import zapierLogo from 'images/partnerLogos/zapier_logo.png';
-
-const partners = [
+export default [
   {
     name: 'APEX Systems',
     link: 'https://apexsystems.com',
-    imgSource: apexLogo,
+    imgSource: 'https://s3.amazonaws.com/operationcode-assets/partnerLogos/apex_systems.png'
   },
   {
     name: 'GitHub',
     link: 'https://github.com',
-    imgSource: githubLogo,
+    imgSource: 'https://s3.amazonaws.com/operationcode-assets/partnerLogos/github.png'
+  },
+  {
+    name: '1Password',
+    link: 'https://1password.com/',
+    imgSource: 'https://s3.amazonaws.com/operationcode-assets/partnerLogos/1password.png'
   },
   {
     name: 'Docker',
     link: 'https://docker.com',
-    imgSource: dockerLogo,
+    imgSource: 'https://s3.amazonaws.com/operationcode-assets/partnerLogos/docker.png'
   },
   {
     name: 'Oracle',
     link: 'https://oracle.com',
-    imgSource: oracleLogo,
+    imgSource: 'https://s3.amazonaws.com/operationcode-assets/partnerLogos/oracle.png'
   },
   {
-    name: "O'reilly Media",
+    name: "O'Reilly Media",
     link: 'https://oreilly.com',
-    imgSource: oreillyLogo,
+    imgSource: 'https://s3.amazonaws.com/operationcode-assets/partnerLogos/oreilly.png'
   },
   {
     name: 'HackerRank',
     link: 'https://hackerrank.com',
-    imgSource: hackerrankLogo,
+    imgSource: 'https://s3.amazonaws.com/operationcode-assets/partnerLogos/hackerrank.png'
   },
   {
     name: 'Zapier',
     link: 'https://zapier.com',
-    imgSource: zapierLogo,
-  },
+    imgSource: 'https://s3.amazonaws.com/operationcode-assets/partnerLogos/zapier.png'
+  }
 ];
-
-export default partners;


### PR DESCRIPTION
# Description of changes
- Use AWS links for all partner images
- Implement 1Password

# Issue Resolved
<!-- Keeping the format 'Fixes #123' will automatically close the issue when this PR is merged -->
Fixes #1030 

<img width="1434" alt="screen shot 2018-08-16 at 1 44 49 pm" src="https://user-images.githubusercontent.com/9523719/44234181-d48dee00-a15a-11e8-97c6-5cfcd2db63d3.png">

