### PR TITLE
Set featured jobs whose links are 404-ing to inactive

### DIFF
--- a/src/scenes/home/jobs/featuredJobs.json
+++ b/src/scenes/home/jobs/featuredJobs.json
@@ -7,7 +7,7 @@
     "state": "",
     "country": "Any",
     "description": "As a Technical Product Marketing Manager, you will work closely with our marketing, engineering, business development and sales team, and partners to help them understand how core GitLab technical value offerings solve customer problems as well as educate them about market competitors.  You will be responsible for technical marketing content and representing GitLab as a technical evangelist at key trade shows and customer meetings.",
-    "status": "active",
+    "status": "inactive",
     "remote": true,
     "tags": [
       "Marketing",
@@ -22,7 +22,7 @@
     "state": "",
     "country": "Americas",
     "description": "Our database engineer is a hybrid role: part developer, part database expert. You will spend the majority of your time making application changes to improve database performance, availability, and reliability; though you will also spend time working on the database infrastructure that powers GitLab.com. Infrastructure work involves (but is not limited to) tasks such as making configuration changes, adjusting monitoring, and upgrading the database.",
-    "status": "active",
+    "status": "inactive",
     "remote": true,
     "tags": [
       "Infrastructure",
@@ -37,7 +37,7 @@
     "state": "",
     "country": "Asia Pacific",
     "description": "GitLab is looking for a highly motivated, sales-focused field marketer who will be responsible for supporting our Asia Pacific (APAC) sales team. A successful Field Marketing Manager has strong understanding of sales-focused marketing as well as our audiences of enterprise IT leaders, IT ops practitioners, and developers. They enjoy taking charge of regional marketing programs, detailed planning, proactive communication, and flawlessly delivering memorable marketing experiences supporting our sales objectives.",
-    "status": "active",
+    "status": "inactive",
     "remote": true,
     "tags": [
       "Marketing",
@@ -52,7 +52,7 @@
     "state": "Colorado",
     "country": "United States",
     "description": "We are seeking a Software Engineer to join the renowned SBIRS Software Development Team. The selected candidate will be a part of a new and innovative effort to design, develop, and test software solutions supporting ground system software, special projects, new business initiatives, and modernization efforts within our development environment. The candidate will work in a cohesive team environment with opportunities to expand across multiple projects and career growth. Only a Secret Clearance is required to start, and there are multiple openings for each position.",
-    "status": "active",
+    "status": "inactive",
     "remote": false,
     "tags": [
       "Java",
@@ -82,7 +82,7 @@
     "state": "Colorado",
     "country": "United States",
     "description": "We are seeking a Software Engineer to join our dynamic and growing team! The selected candidate will design, develop, and test software solutions across our contracted efforts, supporting multiple baselines in defect resolution as well as enhancements, special projects, new business initiatives, and modernization efforts. The successful candidate will be a passionate coder, someone who loves a challenge and always rises to the occasion to ensure success. They embrace modern development practices and insist that others do as well. Only a Secret Clearance is required to start, and there are multiple openings for each position.",
-    "status": "active",
+    "status": "inactive",
     "remote": false,
     "tags": [
       "Java",


### PR DESCRIPTION
# Description of changes
<!-- What does this PR change and why -->
All but one of the Featured Jobs on our jobs page link to a 404/not-found page, which indicates that the postings are no longer active.  Changed the JSON for those jobs to `"status": "inactive"` in the JSON data source, which will prevent them from displaying on the page.

We are continuing to display one Featured Job, which still has an active job posting URL to link to.