### PR TITLE
#1029 - Replace bug reporting link with mailto:tech@operationcode.org

### DIFF
--- a/src/scenes/home/footer/footer.js
+++ b/src/scenes/home/footer/footer.js
@@ -9,7 +9,7 @@ const Footer = () => (
   <div className={styles.footer}>
     <div className={styles.content}>
       <div className={styles.outerFooterGroupSocial}>
-        <div className={styles.email} >
+        <div className={styles.email}>
           <a href="mailto:contact@operationcode.org">contact@operationcode.org</a>
         </div>
         <SocialMedia />
@@ -17,13 +17,13 @@ const Footer = () => (
       <div className={styles.logo}>
         <img src={centerLogo} alt="Operation Code Logo" />
         <p className={styles.copyright}>
-          Copyright {`${(new Date()).getUTCFullYear()} `}
+          Copyright {`${new Date().getUTCFullYear()} `}
           <br className={styles.copyrightLineBreak} />
           Operation Code™
         </p>
       </div>
       <div className={styles.outerFooterGroupLinks}>
-        <div className={styles.blockGroup} >
+        <div className={styles.blockGroup}>
           <Link to="/about">About</Link>
           <Link to="/press">Press</Link>
           <Link to="/branding">Branding</Link>
@@ -31,10 +31,22 @@ const Footer = () => (
           <Link to="/team">Team</Link>
         </div>
         <div className={styles.blockGroup}>
-          <a href="https://github.com/OperationCode/operationcode_frontend/issues/new" target="_blank" rel="noopener noreferrer">Report A Bug</a>
-          <a href="https://smile.amazon.com/ch/47-4247572" target="_blank" rel="noopener noreferrer">Amazon Smile</a>
+          <a href="mailto:tech@operationcode.org?Subject=Bug%20Report">Report A Bug</a>
+          <a
+            href="https://smile.amazon.com/ch/47-4247572"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Amazon Smile
+          </a>
           <Link to="/contact">Contact</Link>
-          <a href="https://www.iubenda.com/privacy-policy/8174861" target="_blank" rel="noopener noreferrer">Privacy</a>
+          <a
+            href="https://www.iubenda.com/privacy-policy/8174861"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Privacy
+          </a>
           <Link to="/terms">Terms of Service</Link>
         </div>
         <ScrollUpButton />


### PR DESCRIPTION
# Description of changes
Replaced the bug reporting link with mailTo tech@operationcode.org.
We want to make the website suggstion form more user friendly and It's currently not user friendly because users must create github accounts and follow our template. 

# Issue Resolved
https://github.com/OperationCode/operationcode_frontend/issues/1029
